### PR TITLE
Fixed versions for better CI/CD and Zulu to provide that

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.Java }}
-        distribution: 'temurin'
+        distribution: 'zulu'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,14 +18,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    strategy:
+       matrix:
+         java: [ '16', '16.0.1' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 16
       uses: actions/setup-java@v2
       with:
-        java-version: '16'
-        distribution: 'adopt'
+        java-version: ${{ matrix.Java }}
+        distribution: 'temurin'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build
     - uses: "marvinpinto/action-automatic-releases@latest"
+      if: ${{ matrix.Java == '16' }}
       with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest-1.17"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.Java }}
-        distribution: 'temurin'
+        distribution: 'zulu'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,14 +9,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java: [ '16', '16.0.1' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 16
       uses: actions/setup-java@v2
       with:
-        java-version: '16'
-        distribution: 'adopt'
+        java-version: ${{ matrix.Java }}
+        distribution: 'temurin'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle


### PR DESCRIPTION
When you use the major release versions, e.g., 11 or 16, you'll use whatever the latest release of that major release is, so it is good to also include a fixed version, e.g., 11.0.3 or 16.0.1 so that, if the fixed version is green while the major version is red, you'll know the problem is with the latest version rather than the code that you've written yourself. Adopt is no more, Temurin and Zulu are the options available instead, and Zulu provides more versions since it has been around longer than Temurin.