### PR TITLE
Fix OreSim Crash

### DIFF
--- a/src/main/java/anticope/rejects/modules/OreSim.java
+++ b/src/main/java/anticope/rejects/modules/OreSim.java
@@ -231,6 +231,12 @@ public class OreSim extends Module {
         if (seed == null) return;
         worldSeed = seed;
         oreConfig = Ore.getConfig(Seeds.get().getSeed().version);
+        if (oreConfig == null) {
+            error("Ore Sim only works with seeds from version 1.14 or higher. (Current seed is from version " + Seeds.get().getSeed().version.toString() + ")");
+            this.toggle();
+            return;
+        }
+
         chunkRenderers.clear();
         if (mc.world != null && worldSeed != null) {
             loadVisibleChunks();


### PR DESCRIPTION
Fixes a crash when the seed's version is too old
(Ore.getConfig() returns null, resulting in a NullPointerException.)