### PR TITLE
more rendering options to New Chunks

### DIFF
--- a/src/main/java/anticope/rejects/modules/NewChunks.java
+++ b/src/main/java/anticope/rejects/modules/NewChunks.java
@@ -1,7 +1,6 @@
 package anticope.rejects.modules;
 
 import anticope.rejects.MeteorRejectsAddon;
-import meteordevelopment.orbit.EventHandler;
 import meteordevelopment.meteorclient.events.packets.PacketEvent;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.renderer.ShapeMode;
@@ -9,10 +8,16 @@ import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
+import meteordevelopment.orbit.EventHandler;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.nbt.NbtCompound;
-import net.minecraft.network.packet.s2c.play.*;
-import net.minecraft.util.math.*;
+import net.minecraft.network.packet.s2c.play.BlockUpdateS2CPacket;
+import net.minecraft.network.packet.s2c.play.ChunkDataS2CPacket;
+import net.minecraft.network.packet.s2c.play.ChunkDeltaUpdateS2CPacket;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.Direction;
 import net.minecraft.world.chunk.WorldChunk;
 
 import java.util.*;
@@ -23,136 +28,172 @@ import java.util.*;
 public class NewChunks extends Module {
 
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
+	private final SettingGroup sgRender = settings.createGroup("Render");
 
-    private final Setting<Boolean> remove = sgGeneral.add(new BoolSetting.Builder()
-            .name("remove")
-            .description("Removes the cached chunks when disabling the module.")
-            .defaultValue(true)
-            .build()
+	// general
+
+	private final Setting<Boolean> remove = sgGeneral.add(new BoolSetting.Builder()
+        .name("remove")
+        .description("Removes the cached chunks when disabling the module.")
+        .defaultValue(true)
+        .build()
     );
 
-    private final Setting<SettingColor> newChunksColor = sgGeneral.add(new ColorSetting.Builder()
-            .name("new-chunks-color")
-            .description("Color of the chunks that are (most likely) completely new.")
-            .defaultValue(new SettingColor(204, 153, 217))
-            .build()
-    );
+	// render
+	public final Setting<Integer> renderHeight = sgRender.add(new IntSetting.Builder()
+			.name("render-height")
+			.description("The height at which new chunks will be rendered")
+			.defaultValue(0)
+			.min(-64)
+			.sliderRange(-64,319)
+			.build()
+	);
 
-    private final Setting<SettingColor> oldChunksColor = sgGeneral.add(new ColorSetting.Builder()
-            .name("old-chunks-color")
-            .description("Color of the chunks that have (most likely) been loaded before.")
-            .defaultValue(new SettingColor(230, 51, 51))
-            .build()
-    );
-    
-    private Set<ChunkPos> newChunks = Collections.synchronizedSet(new HashSet<>());
-    private Set<ChunkPos> oldChunks = Collections.synchronizedSet(new HashSet<>());
+	private final Setting<ShapeMode> shapeMode = sgRender.add(new EnumSetting.Builder<ShapeMode>()
+			.name("shape-mode")
+			.description("How the shapes are rendered.")
+			.defaultValue(ShapeMode.Both)
+			.build()
+	);
+
+	private final Setting<SettingColor> newChunksSideColor = sgRender.add(new ColorSetting.Builder()
+			.name("new-chunks-side-color")
+			.description("Color of the chunks that are (most likely) completely new.")
+			.defaultValue(new SettingColor(255, 0, 0, 75))
+			.visible(() -> shapeMode.get() == ShapeMode.Sides || shapeMode.get() == ShapeMode.Both)
+			.build()
+	);
+
+	private final Setting<SettingColor> oldChunksSideColor = sgRender.add(new ColorSetting.Builder()
+			.name("old-chunks-side-color")
+			.description("Color of the chunks that have (most likely) been loaded before.")
+			.defaultValue(new SettingColor(0, 255, 0, 75))
+			.visible(() -> shapeMode.get() == ShapeMode.Sides || shapeMode.get() == ShapeMode.Both)
+			.build()
+	);
+
+	private final Setting<SettingColor> newChunksLineColor = sgRender.add(new ColorSetting.Builder()
+			.name("new-chunks-line-color")
+			.description("Color of the chunks that are (most likely) completely new.")
+			.defaultValue(new SettingColor(255, 0, 0, 255))
+			.visible(() -> shapeMode.get() == ShapeMode.Lines || shapeMode.get() == ShapeMode.Both)
+			.build()
+	);
+
+	private final Setting<SettingColor> oldChunksLineColor = sgRender.add(new ColorSetting.Builder()
+			.name("old-chunks-line-color")
+			.description("Color of the chunks that have (most likely) been loaded before.")
+			.defaultValue(new SettingColor(0, 255, 0, 255))
+			.visible(() -> shapeMode.get() == ShapeMode.Lines || shapeMode.get() == ShapeMode.Both)
+			.build()
+	);
+
+    private final Set<ChunkPos> newChunks = Collections.synchronizedSet(new HashSet<>());
+    private final Set<ChunkPos> oldChunks = Collections.synchronizedSet(new HashSet<>());
     private static final Direction[] searchDirs = new Direction[] { Direction.EAST, Direction.NORTH, Direction.WEST, Direction.SOUTH, Direction.UP };
-    
+
     public NewChunks() {
         super(MeteorRejectsAddon.CATEGORY,"new-chunks", "Detects completely new chunks using certain traits of them");
     }
 
-    @Override
-    public void onDeactivate() {
-        if (remove.get()) {
-            newChunks.clear();
-            oldChunks.clear();
-        }
-        super.onDeactivate();
-    }
+	@Override
+	public void onDeactivate() {
+		if (remove.get()) {
+			newChunks.clear();
+			oldChunks.clear();
+		}
+		super.onDeactivate();
+	}
 
-    @EventHandler
-    private void onRender(Render3DEvent event) {
-        if (newChunksColor.get().a > 5) {
-            synchronized (newChunks) {
-                for (ChunkPos c : newChunks) {
-                    if (mc.getCameraEntity().getBlockPos().isWithinDistance(c.getStartPos(), 1024)) {
-                        drawBoxOutline(new Box(c.getStartPos(), c.getStartPos().add(16, 0, 16)), newChunksColor.get(), event);
-                    }
-                }
-            }
-        }
+	@EventHandler
+	private void onRender(Render3DEvent event) {
+		if (newChunksLineColor.get().a > 5 || newChunksSideColor.get().a > 5) {
+			synchronized (newChunks) {
+				for (ChunkPos c : newChunks) {
+					if (mc.getCameraEntity().getBlockPos().isWithinDistance(c.getStartPos(), 1024)) {
+						render(new Box(c.getStartPos(), c.getStartPos().add(16, renderHeight.get(), 16)), newChunksSideColor.get(), newChunksLineColor.get(), shapeMode.get(), event);
+					}
+				}
+			}
+		}
 
-        if (oldChunksColor.get().a > 5){
-            synchronized (oldChunks) {
-                for (ChunkPos c : oldChunks) {
-                    if (mc.getCameraEntity().getBlockPos().isWithinDistance(c.getStartPos(), 1024)) {
-                        drawBoxOutline(new Box(c.getStartPos(), c.getStartPos().add(16, 0, 16)), oldChunksColor.get(), event);
-                    }
-                }
-            }
-        }
-    }
+		if (oldChunksLineColor.get().a > 5 || oldChunksSideColor.get().a > 5){
+			synchronized (oldChunks) {
+				for (ChunkPos c : oldChunks) {
+					if (mc.getCameraEntity().getBlockPos().isWithinDistance(c.getStartPos(), 1024)) {
+						render(new Box(c.getStartPos(), c.getStartPos().add(16, renderHeight.get(), 16)), oldChunksSideColor.get(), oldChunksLineColor.get(), shapeMode.get(), event);
+					}
+				}
+			}
+		}
+	}
 
-    private void drawBoxOutline(Box box, Color color, Render3DEvent event) {
-        event.renderer.box(
-                box.minX, box.minY, box.minZ, box.maxX, box.maxY, box.maxZ,
-                new Color(0,0,0,0), color, ShapeMode.Lines, 0
-                );
-    }
+	private void render(Box box, Color sides, Color lines, ShapeMode shapeMode, Render3DEvent event) {
+		event.renderer.box(
+			box.minX, box.minY, box.minZ, box.maxX, box.maxY, box.maxZ, sides, lines, shapeMode, 0);
+	}
 
-    @EventHandler
-    private void onReadPacket(PacketEvent.Receive event) {
-        if (event.packet instanceof ChunkDeltaUpdateS2CPacket) {
-            ChunkDeltaUpdateS2CPacket packet = (ChunkDeltaUpdateS2CPacket) event.packet;
+	@EventHandler
+	private void onReadPacket(PacketEvent.Receive event) {
+		if (event.packet instanceof ChunkDeltaUpdateS2CPacket) {
+			ChunkDeltaUpdateS2CPacket packet = (ChunkDeltaUpdateS2CPacket) event.packet;
 
-            packet.visitUpdates((pos, state) -> {
-                if (!state.getFluidState().isEmpty() && !state.getFluidState().isStill()) {
-                    ChunkPos chunkPos = new ChunkPos(pos);
+			packet.visitUpdates((pos, state) -> {
+				if (!state.getFluidState().isEmpty() && !state.getFluidState().isStill()) {
+					ChunkPos chunkPos = new ChunkPos(pos);
 
-                    for (Direction dir: searchDirs) {
-                        if (mc.world.getBlockState(pos.offset(dir)).getFluidState().isStill() && !oldChunks.contains(chunkPos)) {
-                            newChunks.add(chunkPos);
-                            return;
-                        }
-                    }
-                }
-            });
-        }
+					for (Direction dir: searchDirs) {
+						if (mc.world.getBlockState(pos.offset(dir)).getFluidState().isStill() && !oldChunks.contains(chunkPos)) {
+							newChunks.add(chunkPos);
+							return;
+						}
+					}
+				}
+			});
+		}
 
-        else if (event.packet instanceof BlockUpdateS2CPacket) {
-            BlockUpdateS2CPacket packet = (BlockUpdateS2CPacket) event.packet;
+		else if (event.packet instanceof BlockUpdateS2CPacket) {
+			BlockUpdateS2CPacket packet = (BlockUpdateS2CPacket) event.packet;
 
-            if (!packet.getState().getFluidState().isEmpty() && !packet.getState().getFluidState().isStill()) {
-                ChunkPos chunkPos = new ChunkPos(packet.getPos());
+			if (!packet.getState().getFluidState().isEmpty() && !packet.getState().getFluidState().isStill()) {
+				ChunkPos chunkPos = new ChunkPos(packet.getPos());
 
-                for (Direction dir: searchDirs) {
-                    if (mc.world.getBlockState(packet.getPos().offset(dir)).getFluidState().isStill() && !oldChunks.contains(chunkPos)) {
-                        newChunks.add(chunkPos);
-                        return;
-                    }
-                }
-            }
-        }
+				for (Direction dir: searchDirs) {
+					if (mc.world.getBlockState(packet.getPos().offset(dir)).getFluidState().isStill() && !oldChunks.contains(chunkPos)) {
+						newChunks.add(chunkPos);
+						return;
+					}
+				}
+			}
+		}
 
-        else if (event.packet instanceof ChunkDataS2CPacket && mc.world != null) {
-            ChunkDataS2CPacket packet = (ChunkDataS2CPacket) event.packet;
+		else if (event.packet instanceof ChunkDataS2CPacket && mc.world != null) {
+			ChunkDataS2CPacket packet = (ChunkDataS2CPacket) event.packet;
 
-            ChunkPos pos = new ChunkPos(packet.getX(), packet.getZ());
+			ChunkPos pos = new ChunkPos(packet.getX(), packet.getZ());
 
-            if (!newChunks.contains(pos) && mc.world.getChunkManager().getChunk(packet.getX(), packet.getZ()) == null) {
-                WorldChunk chunk = new WorldChunk(mc.world, pos);
-                try {
-                    chunk.loadFromPacket(packet.getChunkData().getSectionsDataBuf(), new NbtCompound(), packet.getChunkData().getBlockEntities(packet.getX(), packet.getZ()));
-                } catch (ArrayIndexOutOfBoundsException e) {
-                    return;
-                }
-                
+			if (!newChunks.contains(pos) && mc.world.getChunkManager().getChunk(packet.getX(), packet.getZ()) == null) {
+				WorldChunk chunk = new WorldChunk(mc.world, pos);
+				try {
+					chunk.loadFromPacket(packet.getChunkData().getSectionsDataBuf(), new NbtCompound(), packet.getChunkData().getBlockEntities(packet.getX(), packet.getZ()));
+				} catch (ArrayIndexOutOfBoundsException e) {
+					return;
+				}
 
-                for (int x = 0; x < 16; x++) {
-                    for (int y = mc.world.getBottomY(); y < mc.world.getTopY(); y++) {
-                        for (int z = 0; z < 16; z++) {
-                            FluidState fluid = chunk.getFluidState(x, y, z);
 
-                            if (!fluid.isEmpty() && !fluid.isStill()) {
-                                oldChunks.add(pos);
-                                return;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+				for (int x = 0; x < 16; x++) {
+					for (int y = mc.world.getBottomY(); y < mc.world.getTopY(); y++) {
+						for (int z = 0; z < 16; z++) {
+							FluidState fluid = chunk.getFluidState(x, y, z);
+
+							if (!fluid.isEmpty() && !fluid.isStill()) {
+								oldChunks.add(pos);
+								return;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Description
Added  an option to change the height of rendered chunks in new chunks, as well as the ability to switch between box, lines, and both rendering modes. 

## Related Issue
https://github.com/AntiCope/meteor-rejects/issues/141

## Motivation and Context
This change allows for greater customization of the new chunks module.
https://github.com/AntiCope/meteor-rejects/issues/141

## How Has This Been Tested?
I have tested this change by going into a creative world and changing all the rendering modes (box, lines, both), all worked as intended. I have also been playing with this module on a normal survival server and have found on issues.

## Screenshots (if appropriate):
![Screenshot (386)](https://user-images.githubusercontent.com/74616162/180631391-4dd9888e-43b0-4701-b845-0b5f2dc14cb4.png)
![Screenshot (387)](https://user-images.githubusercontent.com/74616162/180631405-b2d264e0-1814-4a03-9a39-15c9ad69db6f.png)
![Screenshot (388)](https://user-images.githubusercontent.com/74616162/180631444-89aa85c0-9bef-4941-85e9-f3441b39f3ec.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] Have you successfully ran tests with your changes locally?
