### PR TITLE
Some of my closed PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@
   - `disableToasts`
 - Flight
   - `stopMomentum`
+- Module
+  - `Duplicate names`
 
 ## Commands
 - `.center`
@@ -108,5 +110,7 @@
 - Radar HUD
 
 ## Config
-- `Http Allowed` - modify what http requests can be made with Meteor's http api
-- `Hidden Modules` - hide modules from module gui. **requires restart when unhiding**
+- `Http Allowed` - Modify what http requests can be made with Meteor's http api
+- `Hidden Modules` - Hide modules from module gui. **requires restart when unhiding**
+- `Load system fonts` - Disabling this for faster launch. You can put font into meteor-client/fonts folder. **requires restart to take effect**
+- `Duplicate module names` - Allow duplicate module names. Best for addon compatibility.

--- a/src/main/java/anticope/rejects/mixin/meteor/FontUtilsMixin.java
+++ b/src/main/java/anticope/rejects/mixin/meteor/FontUtilsMixin.java
@@ -1,0 +1,25 @@
+package anticope.rejects.mixin.meteor;
+
+import anticope.rejects.utils.RejectsConfig;
+import meteordevelopment.meteorclient.MeteorClient;
+import meteordevelopment.meteorclient.utils.render.FontUtils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+@Mixin(FontUtils.class)
+public class FontUtilsMixin {
+    @Inject(method = "getSearchPaths", at = @At("HEAD"), cancellable = true, remap = false)
+    private static void onGetSearchPaths(CallbackInfoReturnable<Set<String>> info) {
+        if (!RejectsConfig.get().loadSystemFonts) {
+            File dir = new File(MeteorClient.FOLDER, "fonts");
+            info.setReturnValue(!dir.mkdirs() ? Collections.singleton(dir.getAbsolutePath()) : new HashSet<>());
+        }
+    }
+}

--- a/src/main/java/anticope/rejects/mixin/meteor/ModuleMixin.java
+++ b/src/main/java/anticope/rejects/mixin/meteor/ModuleMixin.java
@@ -1,0 +1,40 @@
+package anticope.rejects.mixin.meteor;
+
+import anticope.rejects.utils.RejectsConfig;
+import meteordevelopment.meteorclient.systems.modules.Category;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.utils.Utils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Module.class)
+public class ModuleMixin {
+    @Mutable @Shadow public String name;
+
+    @Mutable @Shadow public String title;
+
+    @Inject(method = "<init>", at = @At("TAIL"), remap = false)
+    private void onInit(Category category, String name, String description, CallbackInfo info) {
+        if (RejectsConfig.get().duplicateModuleNames) {
+            this.name = getModuleName(name);
+            this.title = Utils.nameToTitle(this.name);
+        }
+    }
+
+    private static String getModuleName(String name) {
+        boolean dupe = false;
+        for (Module module : Modules.get().getAll()) {
+            if (module.name.equals(name)) {
+                dupe = true;
+                break;
+            }
+        }
+        if (dupe) name += "*";
+        return name;
+    }
+}

--- a/src/main/java/anticope/rejects/mixin/meteor/ModuleMixin.java
+++ b/src/main/java/anticope/rejects/mixin/meteor/ModuleMixin.java
@@ -1,9 +1,9 @@
 package anticope.rejects.mixin.meteor;
 
 import anticope.rejects.utils.RejectsConfig;
+import anticope.rejects.utils.RejectsUtils;
 import meteordevelopment.meteorclient.systems.modules.Category;
 import meteordevelopment.meteorclient.systems.modules.Module;
-import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.Utils;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
@@ -21,20 +21,8 @@ public class ModuleMixin {
     @Inject(method = "<init>", at = @At("TAIL"), remap = false)
     private void onInit(Category category, String name, String description, CallbackInfo info) {
         if (RejectsConfig.get().duplicateModuleNames) {
-            this.name = getModuleName(name);
+            this.name = RejectsUtils.getModuleName(name);
             this.title = Utils.nameToTitle(this.name);
         }
-    }
-
-    private static String getModuleName(String name) {
-        boolean dupe = false;
-        for (Module module : Modules.get().getAll()) {
-            if (module.name.equals(name)) {
-                dupe = true;
-                break;
-            }
-        }
-        if (dupe) name += "*";
-        return name;
     }
 }

--- a/src/main/java/anticope/rejects/utils/ConfigModifier.java
+++ b/src/main/java/anticope/rejects/utils/ConfigModifier.java
@@ -41,7 +41,7 @@ public class ConfigModifier {
     public final Setting<Boolean> duplicateModuleNames = sgRejects.add(new BoolSetting.Builder()
             .name("duplicate-module-names")
             .description("Allow duplicate module names. Best for addon compatibility.")
-            .defaultValue(true)
+            .defaultValue(false)
             .defaultValue(RejectsConfig.get().duplicateModuleNames)
             .onChanged(v -> RejectsConfig.get().duplicateModuleNames = v)
             .build()

--- a/src/main/java/anticope/rejects/utils/ConfigModifier.java
+++ b/src/main/java/anticope/rejects/utils/ConfigModifier.java
@@ -1,13 +1,9 @@
 package anticope.rejects.utils;
 
-import meteordevelopment.meteorclient.settings.EnumSetting;
-import meteordevelopment.meteorclient.settings.ModuleListSetting;
-import meteordevelopment.meteorclient.settings.Setting;
-import meteordevelopment.meteorclient.settings.SettingGroup;
+import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.config.Config;
 import meteordevelopment.meteorclient.systems.modules.Module;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class ConfigModifier {
@@ -27,9 +23,27 @@ public class ConfigModifier {
     public final Setting<List<Module>> hiddenModules = sgRejects.add(new ModuleListSetting.Builder()
             .name("hidden-modules")
             .description("Which modules to hide.")
-            .defaultValue(Arrays.asList())
+            .defaultValue(List.of())
             .defaultValue(RejectsConfig.get().getHiddenModules())
             .onChanged(v -> RejectsConfig.get().setHiddenModules(v))
+            .build()
+    );
+
+    public final Setting<Boolean> loadSystemFonts = sgRejects.add(new BoolSetting.Builder()
+            .name("load-system-fonts")
+            .description("Disabling this for faster launch. You can put font into meteor-client/fonts folder. Restart to take effect.")
+            .defaultValue(true)
+            .defaultValue(RejectsConfig.get().loadSystemFonts)
+            .onChanged(v -> RejectsConfig.get().loadSystemFonts = v)
+            .build()
+    );
+
+    public final Setting<Boolean> duplicateModuleNames = sgRejects.add(new BoolSetting.Builder()
+            .name("duplicate-module-names")
+            .description("Allow duplicate module names. Best for addon compatibility.")
+            .defaultValue(true)
+            .defaultValue(RejectsConfig.get().duplicateModuleNames)
+            .onChanged(v -> RejectsConfig.get().duplicateModuleNames = v)
             .build()
     );
 

--- a/src/main/java/anticope/rejects/utils/RejectsConfig.java
+++ b/src/main/java/anticope/rejects/utils/RejectsConfig.java
@@ -1,21 +1,19 @@
 package anticope.rejects.utils;
 
+import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.systems.System;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
-import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.utils.render.prompts.OkPrompt;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtList;
 import net.minecraft.nbt.NbtString;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class RejectsConfig extends System<RejectsConfig> {
     private static final RejectsConfig INSTANCE = new RejectsConfig();
@@ -28,7 +26,9 @@ public class RejectsConfig extends System<RejectsConfig> {
     }
 
     public HttpAllowed httpAllowed = HttpAllowed.Everything;
-    public Set<String> hiddenModules = new HashSet<String>();
+    public Set<String> hiddenModules = new HashSet<>();
+    public boolean loadSystemFonts = true;
+    public boolean duplicateModuleNames = true;
 
     public RejectsConfig() {
         super("rejects-config");
@@ -43,10 +43,10 @@ public class RejectsConfig extends System<RejectsConfig> {
     public void setHiddenModules(List<Module> newList) {
         if (newList.size() < hiddenModules.size()) {
             OkPrompt.create()
-                .title("Hidden Modules")
-                .message("In order to see the modules you have removed from the list you need to restart Minecraft.")
-                .id("hidden-modules-unhide")
-                .show();
+                    .title("Hidden Modules")
+                    .message("In order to see the modules you have removed from the list you need to restart Minecraft.")
+                    .id("hidden-modules-unhide")
+                    .show();
         }
         hiddenModules.clear();
         for (Module module : newList) {
@@ -58,7 +58,7 @@ public class RejectsConfig extends System<RejectsConfig> {
 
     public List<Module> getHiddenModules() {
         Modules modules = Modules.get();
-        if (modules == null) return Arrays.asList();
+        if (modules == null) return List.of();
         return hiddenModules.stream().map(modules::get).collect(Collectors.toList());
     }
 
@@ -66,6 +66,8 @@ public class RejectsConfig extends System<RejectsConfig> {
     public NbtCompound toTag() {
         NbtCompound tag = new NbtCompound();
         tag.putString("httpAllowed", httpAllowed.toString());
+        tag.putBoolean("loadSystemFonts", loadSystemFonts);
+        tag.putBoolean("duplicateModuleNames", duplicateModuleNames);
 
         NbtList modulesTag = new NbtList();
         for (String module : hiddenModules) modulesTag.add(NbtString.of(module));
@@ -77,6 +79,8 @@ public class RejectsConfig extends System<RejectsConfig> {
     @Override
     public RejectsConfig fromTag(NbtCompound tag) {
         httpAllowed = HttpAllowed.valueOf(tag.getString("httpAllowed"));
+        loadSystemFonts = tag.getBoolean("loadSystemFonts");
+        duplicateModuleNames = tag.getBoolean("duplicateModuleNames");
 
         NbtList valueTag = tag.getList("hiddenModules", 8);
         for (NbtElement tagI : valueTag) {

--- a/src/main/java/anticope/rejects/utils/RejectsConfig.java
+++ b/src/main/java/anticope/rejects/utils/RejectsConfig.java
@@ -28,7 +28,7 @@ public class RejectsConfig extends System<RejectsConfig> {
     public HttpAllowed httpAllowed = HttpAllowed.Everything;
     public Set<String> hiddenModules = new HashSet<>();
     public boolean loadSystemFonts = true;
-    public boolean duplicateModuleNames = true;
+    public boolean duplicateModuleNames = false;
 
     public RejectsConfig() {
         super("rejects-config");

--- a/src/main/java/anticope/rejects/utils/RejectsUtils.java
+++ b/src/main/java/anticope/rejects/utils/RejectsUtils.java
@@ -2,6 +2,8 @@ package anticope.rejects.utils;
 
 import anticope.rejects.utils.seeds.Seeds;
 import meteordevelopment.meteorclient.MeteorClient;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.PostInit;
 public class RejectsUtils {
 
@@ -12,5 +14,16 @@ public class RejectsUtils {
             RejectsConfig.get().save(MeteorClient.FOLDER);
             Seeds.get().save(MeteorClient.FOLDER);
         }));
+    }
+
+    public static String getModuleName(String name) {
+        int dupe = 0;
+        for (Module module : Modules.get().getAll()) {
+            if (module.name.equals(name)) {
+                dupe++;
+                break;
+            }
+        }
+        return dupe == 0 ? name : getModuleName(name + "*".repeat(dupe));
     }
 }

--- a/src/main/resources/meteor-rejects-meteor.mixins.json
+++ b/src/main/resources/meteor-rejects-meteor.mixins.json
@@ -7,7 +7,9 @@
     "ConfigTabMixin",
     "GuiRendererAccessor",
     "HttpMixin",
+    "ModuleMixin",
     "ModulesMixin",
+    "FontUtilsMixin",
     "modules.FlightMixin",
     "modules.NoRenderAccessor"
   ]


### PR DESCRIPTION
- `Load system fonts` - Disabling this for faster launch. You can put font into meteor-client/fonts folder. **requires restart to take effect**
- `Duplicate module names` - Allow duplicate module names. Best for addon compatibility.