### PR TITLE
Fixed Painter performance and added blocks-per-tick option

### DIFF
--- a/src/main/java/anticope/rejects/modules/Painter.java
+++ b/src/main/java/anticope/rejects/modules/Painter.java
@@ -41,6 +41,14 @@ public class Painter extends Module {
             .defaultValue(0)
             .build()
     );
+
+    private final Setting<Integer> bpt = sgGeneral.add(new IntSetting.Builder()
+            .name("blocks-per-tick")
+            .description("Amount of blocks that can be placed in one tick")
+            .min(1)
+            .defaultValue(1)
+            .build()
+    );
     
     private final Setting<Boolean> rotate = sgGeneral.add(new BoolSetting.Builder()
             .name("rotate")
@@ -76,8 +84,7 @@ public class Painter extends Module {
             .defaultValue(true)
             .build()
     );
-    
-    private ArrayList<BlockPos> positions = new ArrayList<>();
+
     private int ticksWaited;
     
     public Painter() {
@@ -102,16 +109,15 @@ public class Painter extends Module {
         }
         
         // Find spots
+        int placed = 0;
         for (BlockPos blockPos : WorldUtils.getSphere(mc.player.getBlockPos(), range.get(), range.get())) {
-            if (shouldPlace(blockPos, block.get())) positions.add(blockPos);
-        }
-        
-        // Place
-        for (BlockPos blockPos : positions) {
-            BlockUtils.place(blockPos, findItemResult, rotate.get(), -100, false);
-    
-            // Delay 0
-            if (delay.get() != 0) break;
+            if (shouldPlace(blockPos, block.get())) {
+                BlockUtils.place(blockPos, findItemResult, rotate.get(), -100, false);
+                placed++;
+
+                // Delay 0
+                if (delay.get() != 0 && placed >= bpt.get()) break;
+            }
         }
     }
     


### PR DESCRIPTION
## Description
Fixed https://github.com/AntiCope/meteor-rejects/issues/59
Also added `blocks-per-tick` option

## Related Issue
https://github.com/AntiCope/meteor-rejects/issues/59

## Motivation and Context
why not

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] Have you successfully ran tests with your changes locally?
