### PR TITLE
Make BlockIn always work when flying or midair

### DIFF
--- a/src/main/java/anticope/rejects/modules/BlockIn.java
+++ b/src/main/java/anticope/rejects/modules/BlockIn.java
@@ -59,22 +59,26 @@ public class BlockIn extends Module {
     
     private final BlockPos.Mutable bp = new BlockPos.Mutable();
     private boolean return_;
+    private double sY;
     
     public BlockIn() {
         super(MeteorRejectsAddon.CATEGORY, "block-in", "Block yourself in using any block.");
     }
-    private double sY;
+    
     @Override
     public void onActivate() {
-        sY=mc.player.getPos().getY();
+        sY = mc.player.getPos().getY();
     }
+    
     @EventHandler
     private void onPreTick(TickEvent.Pre event) {
         if (center.get()) {
-            if (!onlyOnGround.get()){
+            if (!onlyOnGround.get()) {
                 mc.player.setVelocity(0,0,0);
-            mc.player.move(MovementType.SELF, new Vec3d(0, -(sY-Math.floor(sY)), 0));}
-            PlayerUtils.centerPlayer();}
+                mc.player.move(MovementType.SELF, new Vec3d(0, -(sY-Math.floor(sY)), 0));
+            }
+            PlayerUtils.centerPlayer();
+        }
         if (onlyOnGround.get() && !mc.player.isOnGround()) return;
         
         return_ = false;

--- a/src/main/java/anticope/rejects/modules/BlockIn.java
+++ b/src/main/java/anticope/rejects/modules/BlockIn.java
@@ -1,6 +1,8 @@
 package anticope.rejects.modules;
 
 import anticope.rejects.MeteorRejectsAddon;
+import net.minecraft.entity.MovementType;
+import net.minecraft.util.math.Vec3d;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.settings.BoolSetting;
 import meteordevelopment.meteorclient.settings.Setting;
@@ -61,10 +63,18 @@ public class BlockIn extends Module {
     public BlockIn() {
         super(MeteorRejectsAddon.CATEGORY, "block-in", "Block yourself in using any block.");
     }
-    
+    private double sY;
+    @Override
+    public void onActivate() {
+        sY=mc.player.getPos().getY();
+    }
     @EventHandler
     private void onPreTick(TickEvent.Pre event) {
-        if (center.get()) PlayerUtils.centerPlayer();
+        if (center.get()) {
+            if (!onlyOnGround.get()){
+                mc.player.setVelocity(0,0,0);
+            mc.player.move(MovementType.SELF, new Vec3d(0, -(sY-Math.floor(sY)), 0));}
+            PlayerUtils.centerPlayer();}
         if (onlyOnGround.get() && !mc.player.isOnGround()) return;
         
         return_ = false;


### PR DESCRIPTION
Moves you down to the nearest single block location when center player is enabled and only on ground is disabled. Block in would previously skip the block above your head if your head was in the way when enabling it mid-flight
