### PR TITLE
FullNoClip + FullFlight + NoJumpDelay + KnockbackPlus

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@
 - TreeAura (Taken from an [unmerged PR](https://github.com/MeteorDevelopment/meteor-client/pull/2138))
 - FullNoClip
 - FullFlight
+- NoJumpDelay
+- KnockbackPlus
 
 ### Modifications
 - NoRender

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@
 - Server Finder (Ported from [MeteorAdditions](https://github.com/JFronny/MeteorAdditions))
 - TreeAura (Taken from an [unmerged PR](https://github.com/MeteorDevelopment/meteor-client/pull/2138))
 - FullNoClip
-- FullFlight
+- FullFlight (Antikick bypasses by [CCblueX](https://github.com/CCblueX) and [LiveOverflow](https://github.com/LiveOverflow))
 - NoJumpDelay
 - KnockbackPlus
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@
 - SoundLocator
 - Server Finder (Ported from [MeteorAdditions](https://github.com/JFronny/MeteorAdditions))
 - TreeAura (Taken from an [unmerged PR](https://github.com/MeteorDevelopment/meteor-client/pull/2138))
+- FullNoClip
+- FullFlight
 
 ### Modifications
 - NoRender

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,10 @@ dependencies {
 	configurations.implementation.extendsFrom(configurations.extraLibs)
 }
 
+loom {
+    accessWidenerPath = file("src/main/resources/meteor-client.accesswidener")
+}
+
 processResources {
 	inputs.property "version", project.version
 

--- a/src/main/java/anticope/rejects/MeteorRejectsAddon.java
+++ b/src/main/java/anticope/rejects/MeteorRejectsAddon.java
@@ -79,7 +79,7 @@ public class MeteorRejectsAddon extends MeteorAddon {
         modules.add(new SoundLocator());
         modules.add(new TreeAura());
         modules.add(new FullNoClip());
-		modules.add(new FullFlight());
+        modules.add(new FullFlight());
 
         // Commands
         Commands.add(new CenterCommand());

--- a/src/main/java/anticope/rejects/MeteorRejectsAddon.java
+++ b/src/main/java/anticope/rejects/MeteorRejectsAddon.java
@@ -78,6 +78,8 @@ public class MeteorRejectsAddon extends MeteorAddon {
         modules.add(new SkeletonESP());
         modules.add(new SoundLocator());
         modules.add(new TreeAura());
+        modules.add(new FullNoClip());
+		modules.add(new FullFlight());
 
         // Commands
         Commands.add(new CenterCommand());

--- a/src/main/java/anticope/rejects/MeteorRejectsAddon.java
+++ b/src/main/java/anticope/rejects/MeteorRejectsAddon.java
@@ -80,6 +80,8 @@ public class MeteorRejectsAddon extends MeteorAddon {
         modules.add(new TreeAura());
         modules.add(new FullNoClip());
         modules.add(new FullFlight());
+        modules.add(new NoJumpDelay());
+        modules.add(new KnockbackPlus());
 
         // Commands
         Commands.add(new CenterCommand());

--- a/src/main/java/anticope/rejects/modules/FullFlight.java
+++ b/src/main/java/anticope/rejects/modules/FullFlight.java
@@ -44,7 +44,7 @@ public class FullFlight extends Module {
     private final Setting<AntiKickMode> antiKickMode = sgAntiKick.add(new EnumSetting.Builder<AntiKickMode>()
         .name("mode")
         .description("The mode for anti kick.")
-        .defaultValue(AntiKickMode.Old)
+        .defaultValue(AntiKickMode.PaperNew)
         .build()
     );
 	

--- a/src/main/java/anticope/rejects/modules/FullFlight.java
+++ b/src/main/java/anticope/rejects/modules/FullFlight.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Streams;
 import java.util.stream.Stream;
 import meteordevelopment.meteorclient.events.world.CollisionShapeEvent;
 import meteordevelopment.meteorclient.events.entity.player.PlayerMoveEvent;
+import meteordevelopment.meteorclient.events.entity.BoatMoveEvent;
 import meteordevelopment.meteorclient.events.packets.PacketEvent;
 import meteordevelopment.meteorclient.mixininterface.IVec3d;
 import meteordevelopment.meteorclient.mixin.PlayerMoveC2SPacketAccessor;
@@ -24,34 +25,34 @@ import net.minecraft.util.shape.VoxelShapes;
 public class FullFlight extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
     private final SettingGroup sgAntiKick = settings.createGroup("Anti Kick");
-	
+
     private final Setting<Double> speed = sgGeneral.add(new DoubleSetting.Builder()
-        .name("speed")
-        .description("Your speed when flying.")
-        .defaultValue(0.3)
-        .min(0.0)
-        .sliderMax(10)
-        .build()
+            .name("speed")
+            .description("Your speed when flying.")
+            .defaultValue(0.3)
+            .min(0.0)
+            .sliderMax(10)
+            .build()
     );
-	
+
     private final Setting<Boolean> verticalSpeedMatch = sgGeneral.add(new BoolSetting.Builder()
-        .name("vertical-speed-match")
-        .description("Matches your vertical speed to your horizontal speed, otherwise uses vanilla ratio.")
-        .defaultValue(false)
-        .build()
+            .name("vertical-speed-match")
+            .description("Matches your vertical speed to your horizontal speed, otherwise uses vanilla ratio.")
+            .defaultValue(false)
+            .build()
     );
-	
+
     private final Setting<AntiKickMode> antiKickMode = sgAntiKick.add(new EnumSetting.Builder<AntiKickMode>()
-        .name("mode")
-        .description("The mode for anti kick.")
-        .defaultValue(AntiKickMode.PaperNew)
-        .build()
+            .name("mode")
+            .description("The mode for anti kick.")
+            .defaultValue(AntiKickMode.PaperNew)
+            .build()
     );
-	
-	public FullFlight() {
-		super(MeteorRejectsAddon.CATEGORY, "fullflight", "FullFlight.");
-	}
-	
+
+    public FullFlight() {
+        super(MeteorRejectsAddon.CATEGORY, "fullflight", "FullFlight.");
+    }
+
     private double getDir() {
         double dir = 0;
 
@@ -66,54 +67,54 @@ public class FullFlight extends Module {
         }
         return dir;
     }
-	
+
     private double calculateGround() {
         for(double ground = mc.player.getY(); ground > 0D; ground -= 0.05) {
-				Box box = mc.player.getBoundingBox();
-				Box adjustedBox = box.offset(0, ground - mc.player.getY(), 0);
-				
-				Stream<VoxelShape> blockCollisions = Streams.stream(mc.world.getBlockCollisions(mc.player, adjustedBox));
-				
-				if(blockCollisions.findAny().isPresent()) return ground + 0.05;
+            Box box = mc.player.getBoundingBox();
+            Box adjustedBox = box.offset(0, ground - mc.player.getY(), 0);
+
+            Stream<VoxelShape> blockCollisions = Streams.stream(mc.world.getBlockCollisions(mc.player, adjustedBox));
+
+            if(blockCollisions.findAny().isPresent()) return ground + 0.05;
         }
 
         return 0F;
     }
-	
+
     // Copied from ServerPlayNetworkHandler#isEntityOnAir
     private boolean isEntityOnAir(Entity entity) {
         return entity.getWorld().getStatesInBox(entity.getBoundingBox().expand(0.0625).stretch(0.0, -0.55, 0.0)).allMatch(AbstractBlock.AbstractBlockState::isAir);
     }
-	
+
     private int delayLeft = 20;
     private double lastPacketY = Double.MAX_VALUE;
-	
+
     private boolean shouldFlyDown(double currentY, double lastY) {
         if (currentY >= lastY) {
             return true;
         } else return lastY - currentY < 0.03130D;
     }
-	
+
     private void antiKickPacket(PlayerMoveC2SPacket packet, double currentY) {
         // maximum time we can be "floating" is 80 ticks, so 4 seconds max
         if (this.delayLeft <= 0 && this.lastPacketY != Double.MAX_VALUE &&
-            shouldFlyDown(currentY, this.lastPacketY) && isEntityOnAir(mc.player)) {
+                shouldFlyDown(currentY, this.lastPacketY) && isEntityOnAir(mc.player)) {
             // actual check is for >= -0.03125D, but we have to do a bit more than that
             // due to the fact that it's a bigger or *equal* to, and not just a bigger than
             ((PlayerMoveC2SPacketAccessor) packet).setY(lastPacketY - 0.03130D);
-			lastPacketY -= 0.03130D;
-			delayLeft = 20;
+            lastPacketY -= 0.03130D;
+            delayLeft = 20;
         } else {
             lastPacketY = currentY;
-			if (!isEntityOnAir(mc.player))
-				delayLeft = 20;
+            if (!isEntityOnAir(mc.player))
+                delayLeft = 20;
         }
         if (delayLeft > 0) delayLeft--;
     }
-	
+
     @EventHandler
     private void onSendPacket(PacketEvent.Send event) {
-        if (!(event.packet instanceof PlayerMoveC2SPacket packet) || antiKickMode.get() != AntiKickMode.PaperNew) return;
+        if (mc.player.getVehicle() == null || !(event.packet instanceof PlayerMoveC2SPacket packet) || antiKickMode.get() != AntiKickMode.PaperNew) return;
 
         double currentY = packet.getY(Double.MAX_VALUE);
         if (currentY != Double.MAX_VALUE) {
@@ -124,19 +125,19 @@ public class FullFlight extends Module {
             PlayerMoveC2SPacket fullPacket;
             if (packet.changesLook()) {
                 fullPacket = new PlayerMoveC2SPacket.Full(
-                    mc.player.getX(),
-                    mc.player.getY(),
-                    mc.player.getZ(),
-                    packet.getYaw(0),
-                    packet.getPitch(0),
-                    packet.isOnGround()
+                        mc.player.getX(),
+                        mc.player.getY(),
+                        mc.player.getZ(),
+                        packet.getYaw(0),
+                        packet.getPitch(0),
+                        packet.isOnGround()
                 );
             } else {
                 fullPacket = new PlayerMoveC2SPacket.PositionAndOnGround(
-                    mc.player.getX(),
-                    mc.player.getY(),
-                    mc.player.getZ(),
-                    packet.isOnGround()
+                        mc.player.getX(),
+                        mc.player.getY(),
+                        mc.player.getZ(),
+                        packet.isOnGround()
                 );
             }
             event.cancel();
@@ -144,97 +145,97 @@ public class FullFlight extends Module {
             mc.getNetworkHandler().sendPacket(fullPacket);
         }
     }
-	
+
     private int floatingTicks = 0;
-	
+
     @EventHandler
     private void onPlayerMove(PlayerMoveEvent event) {
-		if (antiKickMode.get() == AntiKickMode.PaperNew) {
-                // Resend movement packets
-				((ClientPlayerEntityAccessor) mc.player).setTicksSinceLastPositionPacketSent(20);
+        if (antiKickMode.get() == AntiKickMode.PaperNew) {
+            // Resend movement packets
+            ((ClientPlayerEntityAccessor) mc.player).setTicksSinceLastPositionPacketSent(20);
         }
-		if (floatingTicks >= 20)
-		{
-        switch (antiKickMode.get()) {
-            case New -> {
-				Box box = mc.player.getBoundingBox();
-				Box adjustedBox = box.offset(0, -0.4, 0);
-				
-				Stream<VoxelShape> blockCollisions = Streams.stream(mc.world.getBlockCollisions(mc.player, adjustedBox));
-				
-				if(blockCollisions.findAny().isPresent()) break;
-				
-				mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), mc.player.getY() - 0.4, mc.player.getZ(), mc.player.isOnGround()));
-				mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), mc.player.getY(), mc.player.getZ(), mc.player.isOnGround()));
-				
-				break;
-			}
-            case Old -> {
-				Box box = mc.player.getBoundingBox();
-				Box adjustedBox = box.offset(0, -0.4, 0);
-				
-				Stream<VoxelShape> blockCollisions = Streams.stream(mc.world.getBlockCollisions(mc.player, adjustedBox));
-				
-				if(blockCollisions.findAny().isPresent()) break;
-				
-				double ground = calculateGround();
-				double groundExtra = ground + 0.1D;
-				
-				for(double posY = mc.player.getY(); posY > groundExtra; posY -= 4D) {
-					mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), posY, mc.player.getZ(), true));
+        if (floatingTicks >= 20)
+        {
+            switch (antiKickMode.get()) {
+                case New -> {
+                    Box box = mc.player.getBoundingBox();
+                    Box adjustedBox = box.offset(0, -0.4, 0);
 
-					if(posY - 4D < groundExtra) break; // Prevent next step
-				}
+                    Stream<VoxelShape> blockCollisions = Streams.stream(mc.world.getBlockCollisions(mc.player, adjustedBox));
 
-				mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), groundExtra, mc.player.getZ(), true));
+                    if(blockCollisions.findAny().isPresent()) break;
+
+                    mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), mc.player.getY() - 0.4, mc.player.getZ(), mc.player.isOnGround()));
+                    mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), mc.player.getY(), mc.player.getZ(), mc.player.isOnGround()));
+
+                    break;
+                }
+                case Old -> {
+                    Box box = mc.player.getBoundingBox();
+                    Box adjustedBox = box.offset(0, -0.4, 0);
+
+                    Stream<VoxelShape> blockCollisions = Streams.stream(mc.world.getBlockCollisions(mc.player, adjustedBox));
+
+                    if(blockCollisions.findAny().isPresent()) break;
+
+                    double ground = calculateGround();
+                    double groundExtra = ground + 0.1D;
+
+                    for(double posY = mc.player.getY(); posY > groundExtra; posY -= 4D) {
+                        mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), posY, mc.player.getZ(), true));
+
+                        if(posY - 4D < groundExtra) break; // Prevent next step
+                    }
+
+                    mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), groundExtra, mc.player.getZ(), true));
 
 
-				for(double posY = groundExtra; posY < mc.player.getY(); posY += 4D) {
-					mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), posY, mc.player.getZ(), mc.player.isOnGround()));
+                    for(double posY = groundExtra; posY < mc.player.getY(); posY += 4D) {
+                        mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), posY, mc.player.getZ(), mc.player.isOnGround()));
 
-					if(posY + 4D > mc.player.getY()) break; // Prevent next step
-				}
+                        if(posY + 4D > mc.player.getY()) break; // Prevent next step
+                    }
 
-				mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), mc.player.getY(), mc.player.getZ(), mc.player.isOnGround()));
-				
-				break;
-			}
-		}
-		floatingTicks = 0;
-		}
-		
-		if (PlayerUtils.isMoving()) {
-			double dir = getDir();
-			
-			double xDir = Math.cos(Math.toRadians(dir + 90));
-			double zDir = Math.sin(Math.toRadians(dir + 90));
-			
-			((IVec3d) event.movement).setXZ(xDir * speed.get(), zDir * speed.get());
-		}
-		else {
-			((IVec3d) event.movement).setXZ(0, 0);
-		}
-		
-		float ySpeed = 0;
-		
-		if (mc.options.jumpKey.isPressed())
-			ySpeed += speed.get();
-		if (mc.options.sneakKey.isPressed())
-			ySpeed -= speed.get();
-		((IVec3d) event.movement).setY(verticalSpeedMatch.get() ? ySpeed : ySpeed/2);
-		
-		if (floatingTicks < 20)
-			if (ySpeed >= -0.1)
-				floatingTicks++;
-			else if (antiKickMode.get() == AntiKickMode.New)
-				floatingTicks = 0;
-	}
-	
+                    mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), mc.player.getY(), mc.player.getZ(), mc.player.isOnGround()));
+
+                    break;
+                }
+            }
+            floatingTicks = 0;
+        }
+
+        if (PlayerUtils.isMoving()) {
+            double dir = getDir();
+
+            double xDir = Math.cos(Math.toRadians(dir + 90));
+            double zDir = Math.sin(Math.toRadians(dir + 90));
+
+            ((IVec3d) event.movement).setXZ(xDir * speed.get(), zDir * speed.get());
+        }
+        else {
+            ((IVec3d) event.movement).setXZ(0, 0);
+        }
+
+        float ySpeed = 0;
+
+        if (mc.options.jumpKey.isPressed())
+            ySpeed += speed.get();
+        if (mc.options.sneakKey.isPressed())
+            ySpeed -= speed.get();
+        ((IVec3d) event.movement).setY(verticalSpeedMatch.get() ? ySpeed : ySpeed/2);
+
+        if (floatingTicks < 20)
+            if (ySpeed >= -0.1)
+                floatingTicks++;
+            else if (antiKickMode.get() == AntiKickMode.New)
+                floatingTicks = 0;
+    }
+
     public enum AntiKickMode {
         Old,
         New,
-		PaperNew,
+        PaperNew,
         None
     }
-	
+
 }

--- a/src/main/java/anticope/rejects/modules/FullFlight.java
+++ b/src/main/java/anticope/rejects/modules/FullFlight.java
@@ -90,7 +90,7 @@ public class FullFlight extends Module {
 				
 				if(blockCollisions.findAny().isPresent()) break;
 				
-				mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), mc.player.getY() - 0.4, mc.player.getZ(), mc.player.isOnGround()));
+				mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), mc.player.getY() - 0.05, mc.player.getZ(), mc.player.isOnGround()));
 				mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), mc.player.getY(), mc.player.getZ(), mc.player.isOnGround()));
 				
 				break;
@@ -149,7 +149,7 @@ public class FullFlight extends Module {
 			ySpeed -= speed.get();
 		((IVec3d) event.movement).setY(verticalSpeedMatch.get() ? ySpeed : ySpeed/2);
 		
-		if (ySpeed >= 0 && floatingTicks < 40)
+		if (ySpeed >= -0.05 && floatingTicks < 40)
 			floatingTicks++;
 	}
 	

--- a/src/main/java/anticope/rejects/modules/FullFlight.java
+++ b/src/main/java/anticope/rejects/modules/FullFlight.java
@@ -1,0 +1,162 @@
+package anticope.rejects.modules;
+
+import anticope.rejects.MeteorRejectsAddon;
+import com.google.common.collect.Streams;
+import java.util.stream.Stream;
+import meteordevelopment.meteorclient.events.world.CollisionShapeEvent;
+import meteordevelopment.meteorclient.events.entity.player.PlayerMoveEvent;
+import meteordevelopment.meteorclient.mixininterface.IVec3d;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.settings.*;
+import meteordevelopment.meteorclient.utils.Utils;
+import meteordevelopment.meteorclient.utils.player.PlayerUtils;
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.util.shape.VoxelShapes;
+
+public class FullFlight extends Module {
+    private final SettingGroup sgGeneral = settings.getDefaultGroup();
+    private final SettingGroup sgAntiKick = settings.createGroup("Anti Kick");
+	
+    private final Setting<Double> speed = sgGeneral.add(new DoubleSetting.Builder()
+        .name("speed")
+        .description("Your speed when flying.")
+        .defaultValue(0.3)
+        .min(0.0)
+        .sliderMax(10)
+        .build()
+    );
+	
+    private final Setting<Boolean> verticalSpeedMatch = sgGeneral.add(new BoolSetting.Builder()
+        .name("vertical-speed-match")
+        .description("Matches your vertical speed to your horizontal speed, otherwise uses vanilla ratio.")
+        .defaultValue(false)
+        .build()
+    );
+	
+    private final Setting<AntiKickMode> antiKickMode = sgAntiKick.add(new EnumSetting.Builder<AntiKickMode>()
+        .name("mode")
+        .description("The mode for anti kick.")
+        .defaultValue(AntiKickMode.Old)
+        .build()
+    );
+	
+	public FullFlight() {
+		super(MeteorRejectsAddon.CATEGORY, "fullflight", "FullFlight.");
+	}
+	
+    private double getDir() {
+        double dir = 0;
+
+        if (Utils.canUpdate()) {
+            dir = mc.player.getYaw() + ((mc.player.forwardSpeed < 0) ? 180 : 0);
+
+            if (mc.player.sidewaysSpeed > 0) {
+                dir += -90F * ((mc.player.forwardSpeed < 0) ? -0.5F : ((mc.player.forwardSpeed > 0) ? 0.5F : 1F));
+            } else if (mc.player.sidewaysSpeed < 0) {
+                dir += 90F * ((mc.player.forwardSpeed < 0) ? -0.5F : ((mc.player.forwardSpeed > 0) ? 0.5F : 1F));
+            }
+        }
+        return dir;
+    }
+	
+    private double calculateGround() {
+        for(double ground = mc.player.getY(); ground > 0D; ground -= 0.05) {
+				Box box = mc.player.getBoundingBox();
+				Box adjustedBox = box.offset(0, ground - mc.player.getY(), 0);
+				
+				Stream<VoxelShape> blockCollisions = Streams.stream(mc.world.getBlockCollisions(mc.player, adjustedBox));
+				
+				if(blockCollisions.findAny().isPresent()) return ground;
+        }
+
+        return 0F;
+    }
+	
+    private int floatingTicks = 0;
+	
+    @EventHandler
+    private void onPlayerMove(PlayerMoveEvent event) {
+		if (floatingTicks >= 40)
+		{
+        switch (antiKickMode.get()) {
+            case New -> {
+				Box box = mc.player.getBoundingBox();
+				Box adjustedBox = box.offset(0, -0.4, 0);
+				
+				Stream<VoxelShape> blockCollisions = Streams.stream(mc.world.getBlockCollisions(mc.player, adjustedBox));
+				
+				if(blockCollisions.findAny().isPresent()) break;
+				
+				mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), mc.player.getY() - 0.4, mc.player.getZ(), mc.player.isOnGround()));
+				mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), mc.player.getY(), mc.player.getZ(), mc.player.isOnGround()));
+				
+				break;
+			}
+            case Old -> {
+				Box box = mc.player.getBoundingBox();
+				Box adjustedBox = box.offset(0, -0.4, 0);
+				
+				Stream<VoxelShape> blockCollisions = Streams.stream(mc.world.getBlockCollisions(mc.player, adjustedBox));
+				
+				if(blockCollisions.findAny().isPresent()) break;
+				
+				double ground = calculateGround();
+				double groundExtra = ground + 0.5D;
+				
+				for(double posY = mc.player.getY(); posY > groundExtra; posY -= 8D) {
+					mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), posY, mc.player.getZ(), true));
+
+					if(posY - 8D < groundExtra) break; // Prevent next step
+				}
+
+				mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), groundExtra, mc.player.getZ(), true));
+
+
+				for(double posY = groundExtra; posY < mc.player.getY(); posY += 8D) {
+					mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), posY, mc.player.getZ(), mc.player.isOnGround()));
+
+					if(posY + 8D > mc.player.getY()) break; // Prevent next step
+				}
+
+				mc.getNetworkHandler().sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), mc.player.getY(), mc.player.getZ(), mc.player.isOnGround()));
+				
+				break;
+			}
+		}
+		floatingTicks = 0;
+		}
+		
+		if (PlayerUtils.isMoving()) {
+			double dir = getDir();
+			
+			double xDir = Math.cos(Math.toRadians(dir + 90));
+			double zDir = Math.sin(Math.toRadians(dir + 90));
+			
+			((IVec3d) event.movement).setXZ(xDir * speed.get(), zDir * speed.get());
+		}
+		else {
+			((IVec3d) event.movement).setXZ(0, 0);
+		}
+		
+		float ySpeed = 0;
+		
+		if (mc.options.jumpKey.isPressed())
+			ySpeed += speed.get();
+		if (mc.options.sneakKey.isPressed())
+			ySpeed -= speed.get();
+		((IVec3d) event.movement).setY(verticalSpeedMatch.get() ? ySpeed : ySpeed/2);
+		
+		if (ySpeed >= 0 && floatingTicks < 40)
+			floatingTicks++;
+	}
+	
+    public enum AntiKickMode {
+        Old,
+        New,
+        None
+    }
+	
+}

--- a/src/main/java/anticope/rejects/modules/FullFlight.java
+++ b/src/main/java/anticope/rejects/modules/FullFlight.java
@@ -3,9 +3,7 @@ package anticope.rejects.modules;
 import anticope.rejects.MeteorRejectsAddon;
 import com.google.common.collect.Streams;
 import java.util.stream.Stream;
-import meteordevelopment.meteorclient.events.world.CollisionShapeEvent;
 import meteordevelopment.meteorclient.events.entity.player.PlayerMoveEvent;
-import meteordevelopment.meteorclient.events.entity.BoatMoveEvent;
 import meteordevelopment.meteorclient.events.packets.PacketEvent;
 import meteordevelopment.meteorclient.mixininterface.IVec3d;
 import meteordevelopment.meteorclient.mixin.PlayerMoveC2SPacketAccessor;
@@ -20,7 +18,6 @@ import net.minecraft.entity.Entity;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.shape.VoxelShape;
-import net.minecraft.util.shape.VoxelShapes;
 
 public class FullFlight extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();

--- a/src/main/java/anticope/rejects/modules/FullNoClip.java
+++ b/src/main/java/anticope/rejects/modules/FullNoClip.java
@@ -35,6 +35,7 @@ public class FullNoClip extends Module {
 
 	@EventHandler
 	private void onCollision(CollisionShapeEvent event) {
+		if (mc.player.getVehicle() == null)
 			event.shape = VoxelShapes.empty();
 	}
 	

--- a/src/main/java/anticope/rejects/modules/FullNoClip.java
+++ b/src/main/java/anticope/rejects/modules/FullNoClip.java
@@ -1,0 +1,79 @@
+package anticope.rejects.modules;
+
+import anticope.rejects.MeteorRejectsAddon;
+import meteordevelopment.meteorclient.events.world.CollisionShapeEvent;
+import meteordevelopment.meteorclient.events.entity.player.PlayerMoveEvent;
+import meteordevelopment.meteorclient.mixininterface.IVec3d;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.settings.*;
+import meteordevelopment.meteorclient.utils.Utils;
+import meteordevelopment.meteorclient.utils.player.PlayerUtils;
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.util.shape.VoxelShapes;
+
+public class FullNoClip extends Module {
+    private final SettingGroup sgGeneral = settings.getDefaultGroup();
+    private final Setting<Double> speed = sgGeneral.add(new DoubleSetting.Builder()
+        .name("speed")
+        .description("Your speed when noclipping.")
+        .defaultValue(0.3)
+        .min(0.0)
+        .sliderMax(10)
+        .build()
+    );
+	
+    private final Setting<Boolean> verticalSpeedMatch = sgGeneral.add(new BoolSetting.Builder()
+        .name("vertical-speed-match")
+        .description("Matches your vertical speed to your horizontal speed, otherwise uses vanilla ratio.")
+        .defaultValue(false)
+        .build()
+    );
+	
+	public FullNoClip() {
+		super(MeteorRejectsAddon.CATEGORY, "fullnoclip", "FullNoClip.");
+	}
+
+	@EventHandler
+	private void onCollision(CollisionShapeEvent event) {
+			event.shape = VoxelShapes.empty();
+	}
+	
+    private double getDir() {
+        double dir = 0;
+
+        if (Utils.canUpdate()) {
+            dir = mc.player.getYaw() + ((mc.player.forwardSpeed < 0) ? 180 : 0);
+
+            if (mc.player.sidewaysSpeed > 0) {
+                dir += -90F * ((mc.player.forwardSpeed < 0) ? -0.5F : ((mc.player.forwardSpeed > 0) ? 0.5F : 1F));
+            } else if (mc.player.sidewaysSpeed < 0) {
+                dir += 90F * ((mc.player.forwardSpeed < 0) ? -0.5F : ((mc.player.forwardSpeed > 0) ? 0.5F : 1F));
+            }
+        }
+        return dir;
+    }
+	
+    @EventHandler
+    private void onPlayerMove(PlayerMoveEvent event) {
+		if (PlayerUtils.isMoving()) {
+			double dir = getDir();
+			
+			double xDir = Math.cos(Math.toRadians(dir + 90));
+			double zDir = Math.sin(Math.toRadians(dir + 90));
+			
+			((IVec3d) event.movement).setXZ(xDir * speed.get(), zDir * speed.get());
+		}
+		else {
+			((IVec3d) event.movement).setXZ(0, 0);
+		}
+		
+		float ySpeed = 0;
+		
+		if (mc.options.jumpKey.isPressed())
+			ySpeed += speed.get();
+		if (mc.options.sneakKey.isPressed())
+			ySpeed -= speed.get();
+		((IVec3d) event.movement).setY(verticalSpeedMatch.get() ? ySpeed : ySpeed/2);
+	}
+	
+}

--- a/src/main/java/anticope/rejects/modules/KnockbackPlus.java
+++ b/src/main/java/anticope/rejects/modules/KnockbackPlus.java
@@ -1,0 +1,54 @@
+package anticope.rejects.modules;
+
+import anticope.rejects.MeteorRejectsAddon;
+import meteordevelopment.meteorclient.events.packets.PacketEvent;
+import meteordevelopment.meteorclient.mixininterface.IPlayerInteractEntityC2SPacket;
+import meteordevelopment.meteorclient.mixininterface.IVec3d;
+import meteordevelopment.meteorclient.settings.BoolSetting;
+import meteordevelopment.meteorclient.settings.Setting;
+import meteordevelopment.meteorclient.settings.SettingGroup;
+import meteordevelopment.meteorclient.systems.modules.Categories;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.modules.combat.KillAura;
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.network.packet.c2s.play.PlayerInteractEntityC2SPacket;
+import net.minecraft.network.packet.c2s.play.ClientCommandC2SPacket;
+
+public class KnockbackPlus extends Module {
+
+    private final SettingGroup sgGeneral = settings.getDefaultGroup();
+
+    private final Setting<Boolean> ka = sgGeneral.add(new BoolSetting.Builder()
+        .name("only-killaura")
+        .description("Only perform more KB when using killaura.")
+        .defaultValue(false)
+        .build()
+    );
+
+    private PlayerInteractEntityC2SPacket attackPacket;
+    private boolean sendPackets;
+    private int sendTimer;
+    public KnockbackPlus() {
+        super(MeteorRejectsAddon.CATEGORY, "knockback-plus", "Performs more KB when you hit your target.");
+    }
+
+    @EventHandler
+    private void onSendPacket(PacketEvent.Send event) {
+        if (event.packet instanceof IPlayerInteractEntityC2SPacket packet && packet.getType() == PlayerInteractEntityC2SPacket.InteractType.ATTACK) {
+
+            Entity entity = packet.getEntity();
+
+            if (!(entity instanceof LivingEntity) || (entity != Modules.get().get(KillAura.class).getTarget() && ka.get())) return;
+            sendPacket();
+        }
+    }
+
+    @EventHandler
+    private void sendPacket() {
+        ClientCommandC2SPacket packet = new ClientCommandC2SPacket(mc.player, ClientCommandC2SPacket.Mode.START_SPRINTING);
+        mc.player.networkHandler.sendPacket(packet);
+    }
+}

--- a/src/main/java/anticope/rejects/modules/NoJumpDelay.java
+++ b/src/main/java/anticope/rejects/modules/NoJumpDelay.java
@@ -1,0 +1,24 @@
+package anticope.rejects.modules;
+
+import anticope.rejects.MeteorRejectsAddon;
+import meteordevelopment.meteorclient.events.world.TickEvent;
+import meteordevelopment.meteorclient.mixin.LivingEntityAccessor;
+import meteordevelopment.orbit.EventHandler;
+import meteordevelopment.meteorclient.systems.modules.Categories;
+import meteordevelopment.meteorclient.systems.modules.Module;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class NoJumpDelay extends Module {
+
+    public NoJumpDelay() {
+        super(MeteorRejectsAddon.CATEGORY, "no-jump-delay", "NoJumpDelay.");
+    }
+
+    @EventHandler
+    private void onTick(TickEvent.Post event) {
+        ((LivingEntityAccessor) mc.player).setJumpCooldown(0);
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,6 +30,7 @@
     "meteor-rejects.mixins.json",
     "meteor-rejects-meteor.mixins.json"
   ],
+  "accessWidener": "meteor-client.accesswidener",
   "custom": {
     "meteor-client:color": "227,0,0",
     "github:sha": "${gh_hash}"

--- a/src/main/resources/meteor-client.accesswidener
+++ b/src/main/resources/meteor-client.accesswidener
@@ -1,0 +1,73 @@
+accessWidener	v1	named
+
+accessible   class   net/minecraft/client/render/RenderLayer$OutlineMode
+accessible   class   net/minecraft/client/particle/FireworksSparkParticle$Explosion
+accessible   class   net/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket$InteractType
+accessible   class   net/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket$InteractAtHandler
+accessible   class   net/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket$InteractTypeHandler
+accessible   class   net/minecraft/client/world/ClientChunkManager$ClientChunkMap
+
+accessible   field   net/minecraft/client/network/AbstractClientPlayerEntity playerListEntry Lnet/minecraft/client/network/PlayerListEntry;
+
+accessible   field   net/minecraft/client/model/ModelPart cuboids Ljava/util/List;
+accessible   field   net/minecraft/client/model/ModelPart children Ljava/util/Map;
+accessible   class   net/minecraft/client/model/ModelPart$Quad
+accessible   class   net/minecraft/client/model/ModelPart$Vertex
+accessible   field   net/minecraft/client/model/ModelPart$Cuboid sides [Lnet/minecraft/client/model/ModelPart$Quad;
+accessible   method  net/minecraft/client/render/entity/PlayerEntityRenderer getArmPose (Lnet/minecraft/client/network/AbstractClientPlayerEntity;Lnet/minecraft/util/Hand;)Lnet/minecraft/client/render/entity/model/BipedEntityModel$ArmPose;
+accessible   method  net/minecraft/client/render/entity/LivingEntityRenderer setupTransforms (Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/client/util/math/MatrixStack;FFF)V
+accessible   method  net/minecraft/client/render/entity/LivingEntityRenderer scale (Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/client/util/math/MatrixStack;F)V
+accessible   method  net/minecraft/client/render/entity/LivingEntityRenderer getAnimationProgress (Lnet/minecraft/entity/LivingEntity;F)F
+
+accessible   field   net/minecraft/client/render/entity/model/AnimalModel headScaled Z
+accessible   field   net/minecraft/client/render/entity/model/AnimalModel childHeadYOffset F
+accessible   field   net/minecraft/client/render/entity/model/AnimalModel childHeadZOffset F
+accessible   field   net/minecraft/client/render/entity/model/AnimalModel invertedChildHeadScale F
+accessible   field   net/minecraft/client/render/entity/model/AnimalModel invertedChildBodyScale F
+accessible   field   net/minecraft/client/render/entity/model/AnimalModel childBodyYOffset F
+accessible   method  net/minecraft/client/render/entity/model/AnimalModel getHeadParts ()Ljava/lang/Iterable;
+accessible   method  net/minecraft/client/render/entity/model/AnimalModel getBodyParts ()Ljava/lang/Iterable;
+
+accessible   field   net/minecraft/client/render/entity/model/LlamaEntityModel head Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/model/LlamaEntityModel body Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/model/LlamaEntityModel rightHindLeg Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/model/LlamaEntityModel leftHindLeg Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/model/LlamaEntityModel rightFrontLeg Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/model/LlamaEntityModel leftFrontLeg Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/model/LlamaEntityModel rightChest Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/model/LlamaEntityModel leftChest Lnet/minecraft/client/model/ModelPart;
+
+accessible   field   net/minecraft/client/render/entity/model/RabbitEntityModel leftHindLeg Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/model/RabbitEntityModel rightHindLeg Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/model/RabbitEntityModel leftHaunch Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/model/RabbitEntityModel rightHaunch Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/model/RabbitEntityModel body Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/model/RabbitEntityModel leftFrontLeg Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/model/RabbitEntityModel rightFrontLeg Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/model/RabbitEntityModel head Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/model/RabbitEntityModel rightEar Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/model/RabbitEntityModel leftEar Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/model/RabbitEntityModel tail Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/model/RabbitEntityModel nose Lnet/minecraft/client/model/ModelPart;
+
+accessible   field   net/minecraft/client/render/entity/EndCrystalEntityRenderer SINE_45_DEGREES F
+accessible   field   net/minecraft/client/render/entity/EndCrystalEntityRenderer core Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/EndCrystalEntityRenderer frame Lnet/minecraft/client/model/ModelPart;
+accessible   field   net/minecraft/client/render/entity/EndCrystalEntityRenderer bottom Lnet/minecraft/client/model/ModelPart;
+
+accessible   field   net/minecraft/client/render/entity/BoatEntityRenderer texturesAndModels Ljava/util/Map;
+
+accessible   class   net/minecraft/client/render/MapRenderer$MapTexture
+accessible   field   net/minecraft/client/render/MapRenderer$MapTexture texture Lnet/minecraft/client/texture/NativeImageBackedTexture;
+
+accessible   class   net/minecraft/client/option/SimpleOption$Callbacks
+
+accessible   class   net/minecraft/client/gui/screen/ingame/BeaconScreen$BeaconButtonWidget
+accessible   class   net/minecraft/client/gui/screen/ingame/BeaconScreen$EffectButtonWidget
+
+accessible   class   net/minecraft/client/resource/ResourceReloadLogger$ReloadState
+
+accessible   field   net/minecraft/block/AbstractBlock collidable Z
+accessible field net/minecraft/util/math/Direction HORIZONTAL [Lnet/minecraft/util/math/Direction;
+
+accessible   field   net/minecraft/item/ItemGroups INVENTORY Lnet/minecraft/item/ItemGroup;


### PR DESCRIPTION
## Description
Added a NoClip module (called FullNoClip to avoid any issues related to same name modules)
Added a Flight module (called FullFlight for the same reason)
Added NoJumpDelay

## Motivation and Context
There was no NoClip and the Flight was awful, this one is smooth and works well plus it has 1.8 fly kick bypass (Old) and 1.9+ fly kick bypass aswell (New). Has Meteor client's paper 1.9+ bypass (PaperNew). NoJumpDelay and KnockbackPlus got denied from Meteor client.

## How Has This Been Tested?
I tested with a speed indicator, unlike the current Flight module, speed stays constant, even in liquids and cobweb plus it has the same speed when going diagonally than not diagonally unlike base Flight module which goes slightly faster when going diagonally. Clean and efficient.

## Types of changes
Added FullNoClip and FullFlight modules.
Added NoJumpDelay and KnockbackPlus

## Credits
LiquidBounce (CCblueX) for their old antikick fly bypass and their NoJumpDelay idea.
LiveOverflow for their new antikick fly bypass method.
Meteor client for Paper antikick fly bypass method.
Me