### PR TITLE
Small oversight for noclip

### DIFF
--- a/src/main/java/anticope/rejects/mixin/PlayerEntityMixin.java
+++ b/src/main/java/anticope/rejects/mixin/PlayerEntityMixin.java
@@ -19,6 +19,6 @@ public class PlayerEntityMixin {
     }
     @Redirect(method = {"tick", "updatePose"}, at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;isSpectator()Z"))
     private boolean FullNoClip(PlayerEntity player) {
-        return Modules.get().isActive(FullNoClip.class);
+        return player.isSpectator() || Modules.get().isActive(FullNoClip.class);
     }
 }


### PR DESCRIPTION
## Description
Forgot one detail

## Related Issue
Spectator noclip broke because of an oversight, it's a redirect, it always redirects

## Types of changes
Noclip oversight fixed
