### PR TITLE
Update Minecraft wiki link to new domain

### DIFF
--- a/src/main/java/anticope/rejects/utils/seeds/Seeds.java
+++ b/src/main/java/anticope/rejects/utils/seeds/Seeds.java
@@ -88,7 +88,7 @@ public class Seeds extends System<Seeds> {
         return this;
     }
 
-    // https://minecraft.fandom.com/wiki/Seed_(level_generation)#Java_Edition
+    // https://minecraft.wiki/w/Seed_(level_generation)#Java_Edition
     private static long toSeed(String inSeed) {
         try {
             return Long.parseLong(inSeed);


### PR DESCRIPTION
## Description
This PR updates the old wiki link accordingly.

## Motivation and Context
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] Have you successfully ran tests with your changes locally?
