### PR TITLE
Add support for locate command on new versions from 1.18 to 1.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,10 @@ configurations {
 
 dependencies {
 	// This will make it work on most platforms. It automatically chooses the right dependencies at runtime.
-	extraLibs('dev.duti.acheong:cubiomes:1.22.1') { transitive = false }
-	extraLibs('dev.duti.acheong:cubiomes:1.22.1:linux64') { transitive = false }
-	extraLibs('dev.duti.acheong:cubiomes:1.22.1:osx') { transitive = false }
-	extraLibs('dev.duti.acheong:cubiomes:1.22.1:windows64') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.22.2') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.22.2:linux64') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.22.2:osx') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.22.2:windows64') { transitive = false }
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_version}:v2"

--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,10 @@ configurations {
 
 dependencies {
 	// This will make it work on most platforms. It automatically chooses the right dependencies at runtime.
-	extraLibs('dev.duti.acheong:cubiomes:1.22.0') { transitive = false }
-	extraLibs('dev.duti.acheong:cubiomes:1.22.0:linux64') { transitive = false }
-	extraLibs('dev.duti.acheong:cubiomes:1.22.0:osx') { transitive = false }
-	extraLibs('dev.duti.acheong:cubiomes:1.22.0:windows64') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.22.1') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.22.1:linux64') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.22.1:osx') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.22.1:windows64') { transitive = false }
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_version}:v2"

--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,10 @@ configurations {
 
 dependencies {
 	// This will make it work on most platforms. It automatically chooses the right dependencies at runtime.
-	extraLibs('dev.duti.acheong:cubiomes:1.21.4') { transitive = false }
-	extraLibs('dev.duti.acheong:cubiomes:1.21.4:linux64') { transitive = false }
-	extraLibs('dev.duti.acheong:cubiomes:1.21.4:osx') { transitive = false }
-	extraLibs('dev.duti.acheong:cubiomes:1.21.4:windows64') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.22.0') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.22.0:linux64') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.22.0:osx') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.22.0:windows64') { transitive = false }
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_version}:v2"

--- a/build.gradle
+++ b/build.gradle
@@ -16,14 +16,19 @@ repositories {
 	maven { url "https://maven.seedfinding.com/" }
 	maven { url "https://maven-snapshots.seedfinding.com/" }
 	maven { url 'https://jitpack.io' }
+	maven { url 'https://maven.duti.dev/releases' }
 }
-
 configurations {
 	// configuration that holds jars to include in the jar
 	extraLibs
 }
 
 dependencies {
+	// This will make it work on most platforms. It automatically chooses the right dependencies at runtime.
+	extraLibs('dev.duti.acheong:cubiomes:1.21.4') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.21.4:linux64') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.21.4:osx') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.21.4:windows64') { transitive = false }
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_version}:v2"

--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,10 @@ configurations {
 
 dependencies {
 	// This will make it work on most platforms. It automatically chooses the right dependencies at runtime.
-	extraLibs('dev.duti.acheong:cubiomes:1.22.2') { transitive = false }
-	extraLibs('dev.duti.acheong:cubiomes:1.22.2:linux64') { transitive = false }
-	extraLibs('dev.duti.acheong:cubiomes:1.22.2:osx') { transitive = false }
-	extraLibs('dev.duti.acheong:cubiomes:1.22.2:windows64') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.22.3') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.22.3:linux64') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.22.3:osx') { transitive = false }
+	extraLibs('dev.duti.acheong:cubiomes:1.22.3:windows64') { transitive = false }
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_version}:v2"

--- a/src/main/java/anticope/rejects/commands/LocateCommand.java
+++ b/src/main/java/anticope/rejects/commands/LocateCommand.java
@@ -68,7 +68,7 @@ public class LocateCommand extends Command {
 					Pos pos = null;
 					if (cubiomesVersion != null) {
 						pos = Cubiomes.GetNearestStructure(feature, playerPos.getX(), playerPos.getZ(), seed,
-								Cubiomes.MCVersion.MC_1_20, 8);
+								cubiomesVersion);
 					} else {
 						BlockPos bpos = WorldGenUtils.locateFeature(feature, playerPos);
 						pos = new Pos();

--- a/src/main/java/anticope/rejects/commands/LocateCommand.java
+++ b/src/main/java/anticope/rejects/commands/LocateCommand.java
@@ -2,8 +2,12 @@ package anticope.rejects.commands;
 
 import anticope.rejects.arguments.EnumArgumentType;
 import anticope.rejects.utils.WorldGenUtils;
+import anticope.rejects.utils.seeds.Seeds;
+
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.seedfinding.mccore.version.MCVersion;
+
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
@@ -12,43 +16,77 @@ import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import cubitect.Cubiomes;
+import cubitect.Cubiomes.Pos;
 
 import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class LocateCommand extends Command {
 
-    private final static DynamicCommandExceptionType NOT_FOUND = new DynamicCommandExceptionType(o -> {
-        if (o instanceof WorldGenUtils.Feature) {
-            return Text.literal(String.format(
-                    "%s not found.",
-                    Utils.nameToTitle(o.toString().replaceAll("_", "-")))
-            );
-        }
-        return Text.literal("Not found.");
-    });
+	private final static DynamicCommandExceptionType NOT_FOUND = new DynamicCommandExceptionType(o -> {
+		if (o instanceof Cubiomes.StructureType) {
+			return Text.literal(String.format(
+					"%s not found.",
+					Utils.nameToTitle(o.toString().replaceAll("_", "-"))));
+		}
+		return Text.literal("Not found.");
+	});
 
-    public LocateCommand() {
-        super("locate", "Locates structures.", "loc");
-    }
+	public LocateCommand() {
+		super("locate", "Locates structures.", "loc");
+	}
 
-    @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
-        builder.then(literal("feature").then(argument("feature", EnumArgumentType.enumArgument(WorldGenUtils.Feature.stronghold)).executes(ctx -> {
-            WorldGenUtils.Feature feature = EnumArgumentType.getEnum(ctx, "feature", WorldGenUtils.Feature.stronghold);
-            BlockPos pos = WorldGenUtils.locateFeature(feature, mc.player.getBlockPos());
-            if (pos != null) {
-                MutableText text = Text.literal(String.format(
-                        "%s located at ",
-                        Utils.nameToTitle(feature.toString().replaceAll("_", "-"))
-                ));
-                Vec3d coords = new Vec3d(pos.getX(), pos.getY(), pos.getZ());
-                text.append(ChatUtils.formatCoords(coords));
-                text.append(".");
-                info(text);
-                return SINGLE_SUCCESS;
-            }
-            throw NOT_FOUND.create(feature);
-        })));
-    }
+	@Override
+	public void build(LiteralArgumentBuilder<CommandSource> builder) {
+		builder.then(literal("feature")
+				.then(argument("feature", EnumArgumentType.enumArgument(Cubiomes.StructureType.Village)).executes(ctx -> {
+					Cubiomes.StructureType feature = EnumArgumentType.getEnum(ctx, "feature", Cubiomes.StructureType.Village);
+					BlockPos playerPos = mc.player.getBlockPos();
+					long seed = Seeds.get().getSeed().seed;
+					MCVersion version = Seeds.get().getSeed().version;
+					Cubiomes.MCVersion cubiomesVersion = null;
+					if (version.isNewerOrEqualTo(MCVersion.v1_20)) {
+						cubiomesVersion = Cubiomes.MCVersion.MC_1_20;
+					} else if (version.isNewerOrEqualTo(MCVersion.v1_19)) {
+						switch (version) {
+							case v1_19:
+							case v1_19_1:
+								cubiomesVersion = Cubiomes.MCVersion.MC_1_19;
+								break;
+							case v1_19_2:
+							case v1_19_3:
+							case v1_19_4:
+								cubiomesVersion = Cubiomes.MCVersion.MC_1_19_2;
+								break;
+							default:
+								throw new IllegalStateException("Unexpected value: " + version);
+						}
+					} else if (version.isNewerOrEqualTo(MCVersion.v1_18)) {
+						cubiomesVersion = Cubiomes.MCVersion.MC_1_18;
+					}
+					Pos pos = null;
+					if (cubiomesVersion != null) {
+						pos = Cubiomes.GetNearestStructure(feature, playerPos.getX(), playerPos.getZ(), seed,
+								Cubiomes.MCVersion.MC_1_20, 8);
+					} else {
+						BlockPos bpos = WorldGenUtils.locateFeature(feature, playerPos);
+						pos = new Pos();
+						pos.x = bpos.getX();
+						pos.z = bpos.getZ();
+
+					}
+					if (pos != null) {
+						MutableText text = Text.literal(String.format(
+								"%s located at ",
+								Utils.nameToTitle(feature.toString().replaceAll("_", "-"))));
+						Vec3d coords = new Vec3d(pos.x, 0, pos.z);
+						text.append(ChatUtils.formatCoords(coords));
+						text.append(".");
+						info(text);
+						return SINGLE_SUCCESS;
+					}
+					throw NOT_FOUND.create(feature);
+				})));
+	}
 }

--- a/src/main/java/anticope/rejects/commands/LocateCommand.java
+++ b/src/main/java/anticope/rejects/commands/LocateCommand.java
@@ -77,12 +77,17 @@ public class LocateCommand extends Command {
 
 					}
 					if (pos != null) {
+						// Calculate distance
+						int distance = (int) Math.hypot(pos.x - playerPos.getX(), pos.z - playerPos.getZ());
 						MutableText text = Text.literal(String.format(
 								"%s located at ",
 								Utils.nameToTitle(feature.toString().replaceAll("_", "-"))));
 						Vec3d coords = new Vec3d(pos.x, 0, pos.z);
 						text.append(ChatUtils.formatCoords(coords));
 						text.append(".");
+						if (distance > 0) {
+							text.append(String.format(" (%d blocks away)", distance));
+						}
 						info(text);
 						return SINGLE_SUCCESS;
 					}

--- a/src/main/java/anticope/rejects/modules/OreSim.java
+++ b/src/main/java/anticope/rejects/modules/OreSim.java
@@ -212,8 +212,7 @@ public class OreSim extends Module {
 
     @EventHandler
     public void onChunkData(ChunkDataEvent event) {
-        doMathOnChunk(event.chunk);
-        ChunkDataEvent.returnChunkDataEvent(event);
+        doMathOnChunk(event.chunk());
     }
 
     private void doMathOnChunk(Chunk chunk) {

--- a/src/main/java/anticope/rejects/utils/WorldGenUtils.java
+++ b/src/main/java/anticope/rejects/utils/WorldGenUtils.java
@@ -3,6 +3,8 @@ package anticope.rejects.utils;
 import anticope.rejects.utils.seeds.Seed;
 import anticope.rejects.utils.seeds.Seeds;
 import baritone.api.BaritoneAPI;
+import cubitect.Cubiomes;
+
 import com.seedfinding.mcbiome.source.BiomeSource;
 import com.seedfinding.mcfeature.misc.SlimeChunk;
 import com.seedfinding.mcfeature.structure.*;
@@ -126,7 +128,20 @@ public class WorldGenUtils {
         desert_pyramid
     }
 
-    public static BlockPos locateFeature(Feature feature, BlockPos center) {
+    public static BlockPos locateFeature(Cubiomes.StructureType cfeature, BlockPos center) {
+				Feature feature = switch (cfeature) {
+					case Treasure -> Feature.buried_treasure;
+					case Mansion -> Feature.mansion;
+					case Stronghold -> Feature.stronghold;
+					case Fortress -> Feature.nether_fortress;
+					case Monument -> Feature.ocean_monument;
+					case Bastion -> Feature.bastion_remnant;
+					case End_City -> Feature.end_city;
+					case Village -> Feature.village;
+					case Mineshaft -> Feature.mineshaft;
+					case Desert_Pyramid -> Feature.desert_pyramid;
+					default -> null;
+				};
         Seed seed = Seeds.get().getSeed();
         BlockPos pos = null;
         if (!checkIfInDimension(getDimension(feature))) {


### PR DESCRIPTION
## Description
Replace [mc_biome_java](https://github.com/SeedFinding/mc_biome_java) on versions greater than or equal to 1.18

## Related Issue
#316

## Motivation and Context
I want the locate command to work

## How Has This Been Tested?
Tested on MacOS, Windows, and Linux. Pretty much everything works.

It still works on older versions since we reuse old WorldGenUtils below 1.18.

## Screenshots (if appropriate):

![image](https://github.com/AntiCope/meteor-rejects/assets/121417512/37393e3e-0299-40fb-b7ab-f6e0ce2c868c)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] My code follows the code style of this project.
- [x] Have you successfully ran tests with your changes locally?