### PR TITLE
Added book color functionality to ColorSigns

### DIFF
--- a/src/main/java/anticope/rejects/modules/ColorSigns.java
+++ b/src/main/java/anticope/rejects/modules/ColorSigns.java
@@ -2,31 +2,63 @@ package anticope.rejects.modules;
 
 import anticope.rejects.MeteorRejectsAddon;
 import meteordevelopment.meteorclient.events.packets.PacketEvent;
+import meteordevelopment.meteorclient.settings.BoolSetting;
+import meteordevelopment.meteorclient.settings.Setting;
+import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
+import net.minecraft.network.packet.c2s.play.BookUpdateC2SPacket;
 import net.minecraft.network.packet.c2s.play.UpdateSignC2SPacket;
 import net.minecraft.network.packet.s2c.play.GameJoinS2CPacket;
 import net.minecraft.server.MinecraftServer;
 
+import java.util.List;
+
 public class ColorSigns extends Module {
+
+    private final SettingGroup sgGeneral = settings.getDefaultGroup();
+
+    private final Setting<Boolean> signs = sgGeneral.add(new BoolSetting.Builder()
+            .name("signs")
+            .description("Allows you to use colors in signs.")
+            .defaultValue(true)
+            .build()
+    );
+
+    private final Setting<Boolean> books = sgGeneral.add(new BoolSetting.Builder()
+            .name("books")
+            .description("Allows you to use colors in books.")
+            .defaultValue(false)
+            .build()
+    );
 
     public ColorSigns() {
         super(MeteorRejectsAddon.CATEGORY, "color-signs", "Allows you to use colors on signs on NON-PAPER servers (use \"&\" for color symbols)");
     }
-    
+
     @EventHandler
     private void onPacketSend(PacketEvent.Send event) {
         if (event.packet instanceof GameJoinS2CPacket) {
             checkWarning();
             return;
         }
-        if (!(event.packet instanceof UpdateSignC2SPacket)) return;
-        UpdateSignC2SPacket p = (UpdateSignC2SPacket)event.packet;
-        for (int l = 0; l < p.getText().length; l++) {
-            String newText = p.getText()[l].replaceAll("(?i)\u00a7|&([0-9A-FK-OR])", "\u00a7\u00a7$1$1");
-            p.getText()[l] = newText;
+        if (signs.get() && event.packet instanceof UpdateSignC2SPacket packet) {
+            for (int line = 0; line < packet.getText().length; line++) {
+                packet.getText()[line] = packet.getText()[line]
+                        .replaceAll("(?i)(?:&|(?<!§)§)([0-9A-Z])", "§§$1$1");
+            }
         }
-        event.packet = p;
+        if (books.get() && event.packet instanceof BookUpdateC2SPacket packet) {
+            List<String> newPages = packet.getPages().stream().map(text ->
+                    text.replaceAll("(?i)&([0-9A-Z])", "§$1")).toList();
+            // BookUpdateC2SPacket.pages is final, so we need to create a new packet
+            if (!packet.getPages().equals(newPages)) {
+                assert mc.getNetworkHandler() != null;
+                mc.getNetworkHandler().sendPacket(new BookUpdateC2SPacket(
+                        packet.getSlot(), newPages, packet.getTitle()));
+                event.cancel();
+            }
+        }
     }
 
     @Override

--- a/src/main/java/anticope/rejects/modules/ColorSigns.java
+++ b/src/main/java/anticope/rejects/modules/ColorSigns.java
@@ -6,6 +6,7 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.network.packet.c2s.play.UpdateSignC2SPacket;
 import net.minecraft.network.packet.s2c.play.GameJoinS2CPacket;
+import net.minecraft.server.MinecraftServer;
 
 public class ColorSigns extends Module {
 
@@ -35,7 +36,10 @@ public class ColorSigns extends Module {
     }
 
     private void checkWarning() {
-        String brand = mc.player.getServer().getServerModName();
+        assert mc.player != null;
+        MinecraftServer server = mc.player.getServer();
+        if (server == null) return;
+        String brand = server.getServerModName();
         if (brand == null) return;
         if (brand.contains("Paper")) warning("You are on a paper server. Color signs won't work here");
     }


### PR DESCRIPTION
## Description
I fixed a crash that happened to me and added an option to also replace `&` with `§` when writing books.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/AntiCope/meteor-rejects/issues/339

## How Has This Been Tested?
I tested this both with my large modpack and just meteor, it worked fine.

## Screenshots (if appropriate):
![image](https://github.com/AntiCope/meteor-rejects/assets/61618352/2b2a5eba-b255-4f44-9961-05b14faa5c71)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] Have you successfully ran tests with your changes locally?
