### PR TITLE
Ignore invalid nicknames in AntiVanish

### DIFF
--- a/src/main/java/anticope/rejects/modules/AntiVanish.java
+++ b/src/main/java/anticope/rejects/modules/AntiVanish.java
@@ -88,6 +88,8 @@ public class AntiVanish extends Module {
 
                 for (String playerName : completionPlayerCache) {
                     if (Objects.equals(playerName, mc.player.getName().getString())) continue;
+                    if (playerName.contains(" ")) continue;
+                    if (playerName.length() < 3 || playerName.length() > 16) continue;
                     if (joinedOrQuit.test(playerName)) {
                         info("Player joined: " + playerName);
                     }
@@ -95,6 +97,8 @@ public class AntiVanish extends Module {
 
                 for (String playerName : lastUsernames) {
                     if (Objects.equals(playerName, mc.player.getName().getString())) continue;
+                    if (playerName.contains(" ")) continue;
+                    if (playerName.length() < 3 || playerName.length() > 16) continue;
                     if (joinedOrQuit.test(playerName)) {
                         info("Player left: " + playerName);
                     }
@@ -124,6 +128,8 @@ public class AntiVanish extends Module {
                 for (UUID uuid : oldPlayers.keySet()) {
                     if (playerCache.containsKey(uuid)) continue;
                     String name = oldPlayers.get(uuid);
+                    if (name.contains(" ")) continue;
+                    if (name.length() < 3 || name.length() > 16) continue;
                     if (messageCache.stream().noneMatch(s -> s.contains(name))) {
                         warning(name + " has gone into vanish.");
                     }


### PR DESCRIPTION
https://help.minecraft.net/hc/en-us/articles/4408950195341-Minecraft-Java-Edition-Username-VS-Gamertag-FAQ#h_01GE5JWW0210X02JZN2FP9CREC

This is just a mini-fix to AntiVanish module following Minecraft rules about nicknames.