### PR TITLE
Fix initialization errors

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx2G
 # Fabric Properties
 minecraft_version=1.21.4
 yarn_version=1.21.4+build.8
-loader_version=0.16.9
+loader_version=0.16.10
 
 # Mod Properties
 mod_version = 0.3


### PR DESCRIPTION
## Description
Fixed initialization (NoSuchMethodError) errors on launch (upgrading fabric launcher version from 0.16.9 to 0.16.10

## Related Issue
https://github.com/AntiCope/meteor-rejects/issues/411

## Motivation and Context
My motivation is wanting to use the addon, so instead of waiting for a new release, I did it myself, and fixed it.
https://github.com/AntiCope/meteor-rejects/issues/411 (and other NoSuchMethodError issue reports)

## How Has This Been Tested?
I inspected my crash log, inspected the source, changing the fabric launcher version from 0.16.9 to 0.16.10 in gradle.properties.
When I built it, it worked. Using the release version, it didn't.

## Screenshots (if appropriate): N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ yes ] Bug fix (non-breaking change which fixes an issue)
- [ no ] New feature (non-breaking change which adds functionality)
- [ no ] Breaking change (fix or feature that would cause existing functionality to change)
- [ yes ] My code follows the code style of this project.
- [ yes ] Have you successfully ran tests with your changes locally?
