### PR TITLE
Update Minecraft version to 1.21.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties
-minecraft_version=1.21.4
-yarn_version=1.21.4+build.8
+minecraft_version=1.21.10
+yarn_version=1.21.10+build.1
 loader_version=0.16.9
 
 # Mod Properties
@@ -11,4 +11,4 @@ mod_version = 0.3
 maven_group = anticope.rejects
 archives_base_name = meteor-rejects-addon
 
-baritone_version=1.21.4
+baritone_version=1.21.10


### PR DESCRIPTION
Updates Minecraft, Yarn mappings, and Baritone versions from 1.21.4 to 1.21.10 to support the latest Minecraft release.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] Have you successfully ran tests with your changes locally?
