### PR TITLE
1.21.11 improvements + fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
   <!-- Fancy badges -->
   <a href="https://anticope.ml/pages/MeteorAddons.html"><img src="https://img.shields.io/badge/Verified%20Addon-Yes-blueviolet" alt="Verified Addon"></a>
   <a href="https://github.com/AntiCope/meteor-rejects/releases"><img src="https://img.shields.io/badge/Version-v0.1-orange" alt="Version"></a>
-  <img src="https://img.shields.io/badge/spaghetti%20code-yes-success?logo=java" alt="Spagetti code: yes">
-  <img src="https://img.shields.io/badge/Minecraft%20Version-1.20.6-blue" alt="Minecraft Version">
+  <img src="https://img.shields.io/badge/spaghetti%20code-yes-success?logo=java" alt="Spaghetti code: yes">
+  <img src="https://img.shields.io/badge/Minecraft%20Version-1.21.11-blue" alt="Minecraft Version">
   <a href="https://github.com/AntiCope/meteor-rejects/commits/master"><img src="https://img.shields.io/github/last-commit/AntiCope/meteor-rejects?logo=git" alt="Last commit"></a>
   <img src="https://img.shields.io/github/workflow/status/AntiCope/meteor-rejects/Java%20CI%20with%20Gradle?logo=github" alt="build status">
   <img src="https://img.shields.io/github/languages/code-size/AntiCope/meteor-rejects" alt="Code Size">
@@ -27,7 +27,7 @@
 - Download the latest [release](/../../releases) of the mod from the releases tab.
 - Put it in your `.minecraft/mods` folder where you have installed Meteor.
 
-*Note: It is recommended to use the [latest dev build](https://meteorclient.com/download?devBuild=latest) of meteor while using rejects*
+*Note: It is recommended to use the [latest build](https://meteorclient.com/) of meteor while using rejects*
 
 # Features
 ## Modules

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ version = project.mod_version
 group = project.maven_group
 
 repositories {
-	mavenCentral()
 	mavenLocal()
+	mavenCentral()
 	maven { url "https://maven.meteordev.org/releases"}
 	maven { url "https://maven.meteordev.org/snapshots" }
 	maven { url "https://maven.seedfinding.com/" }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx2G
 # Fabric Properties
 minecraft_version=1.21.11
 yarn_version=1.21.11+build.3
-loader_version=0.17.3
+loader_version=0.18.2
 
 # Mod Properties
 mod_version = 0.3

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 pluginManagement {
     repositories {
+        mavenLocal()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'

--- a/src/main/java/anticope/rejects/gui/servers/CleanUpScreen.java
+++ b/src/main/java/anticope/rejects/gui/servers/CleanUpScreen.java
@@ -7,7 +7,6 @@ import meteordevelopment.meteorclient.gui.WindowScreen;
 import meteordevelopment.meteorclient.gui.widgets.containers.WTable;
 import meteordevelopment.meteorclient.gui.widgets.pressable.WCheckbox;
 import meteordevelopment.meteorclient.utils.render.color.Color;
-import net.minecraft.SharedConstants;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.multiplayer.JoinMultiplayerScreen;
 import net.minecraft.client.gui.screens.multiplayer.ServerSelectionList;

--- a/src/main/java/anticope/rejects/gui/themes/rounded/widgets/WMeteorView.java
+++ b/src/main/java/anticope/rejects/gui/themes/rounded/widgets/WMeteorView.java
@@ -13,7 +13,7 @@ public class WMeteorView extends WView implements MeteorWidget {
     @Override
     protected void onRender(GuiRenderer renderer, double mouseX, double mouseY, double delta) {
         if (canScroll && hasScrollBar) {
-            renderer.quad(handleX(), handleY(), handleWidth(), handleHeight(), theme().scrollbarColor.get(handlePressed, handleMouseOver));
+            renderer.quad(handleX(), handleY(), handleWidth(), handleHeight(), theme().scrollbarColor.get(focused, handleMouseOver));
         }
     }
 }

--- a/src/main/java/anticope/rejects/mixin/ClientCommonNetworkHandlerMixin.java
+++ b/src/main/java/anticope/rejects/mixin/ClientCommonNetworkHandlerMixin.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 @Mixin(ClientCommonPacketListenerImpl.class)
-public class ClientCommonNetwokHandlerMixin {
+public class ClientCommonNetworkHandlerMixin {
 	@Inject(method = "onDisconnect", at = @At("HEAD"), cancellable = true)
 	private void onDisconnected(DisconnectionDetails info, CallbackInfo ci) {
 		if (Modules.get().isActive(SilentDisconnect.class) && mc.level != null && mc.player != null) {

--- a/src/main/java/anticope/rejects/mixin/Deadmau5FeatureRendererMixin.java
+++ b/src/main/java/anticope/rejects/mixin/Deadmau5FeatureRendererMixin.java
@@ -1,6 +1,7 @@
 package anticope.rejects.mixin;
 
 import anticope.rejects.modules.Rendering;
+import com.mojang.blaze3d.vertex.PoseStack;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.entity.layers.Deadmau5EarsLayer;
@@ -12,25 +13,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Deadmau5EarsLayer.class)
 public class Deadmau5FeatureRendererMixin {
-    @Inject(method = "submit", at = @At("HEAD"), cancellable = true)
-    private void onRender(com.mojang.blaze3d.vertex.PoseStack matrixStack, SubmitNodeCollector queue, int light, AvatarRenderState renderState, float limbAngle, float limbDistance, CallbackInfo ci) {
-        // Check if Modules system is initialized
+    @Inject(
+        method = "submit(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/client/renderer/entity/state/AvatarRenderState;FF)V",
+        at = @At("HEAD")
+    )
+    private void onRender(PoseStack poseStack, SubmitNodeCollector collector, int light, AvatarRenderState renderState, float f, float g, CallbackInfo ci) {
         if (Modules.get() != null) {
             Rendering renderingModule = Modules.get().get(Rendering.class);
             if (renderingModule != null && renderingModule.deadmau5EarsEnabled()) {
-                // Allow rendering by not canceling
-                return;
+                renderState.showExtraEars = true;
             }
-        }
-
-        // Default vanilla behavior: only render for "deadmau5"
-        if (renderState.nameTag != null) {
-            String playerName = renderState.nameTag.getString();
-            if (!playerName.equals("deadmau5")) {
-                ci.cancel();
-            }
-        } else {
-            ci.cancel();
         }
     }
 }

--- a/src/main/java/anticope/rejects/mixin/LivingEntityRendererMixin.java
+++ b/src/main/java/anticope/rejects/mixin/LivingEntityRendererMixin.java
@@ -2,7 +2,6 @@ package anticope.rejects.mixin;
 
 import anticope.rejects.modules.Rendering;
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.math.Axis;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -20,13 +19,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(LivingEntityRenderer.class)
 public class LivingEntityRendererMixin<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> {
 
-    @Inject(method = "setupRotations", at = @At(value = "TAIL"))
+    @Inject(method = "setupRotations", at = @At("HEAD"))
     private void dinnerboneEntities(S state, PoseStack matrices, float animationProgress, float bodyYaw, CallbackInfo ci) {
+        if (state instanceof AvatarRenderState) return;
+        if (Modules.get() == null) return;
         Rendering renderingModule = Modules.get().get(Rendering.class);
-        if (renderingModule == null) return;
-        if ((!(state instanceof AvatarRenderState)) && renderingModule.dinnerboneEnabled()) {
-            matrices.translate(0.0D, state.boundingBoxHeight + 0.1F, 0.0D);
-            matrices.mulPose(Axis.ZP.rotationDegrees(180.0F));
+        if (renderingModule != null && renderingModule.dinnerboneEnabled()) {
+            state.isUpsideDown = true;
         }
     }
 

--- a/src/main/java/anticope/rejects/mixin/TexturedRenderLayersMixin.java
+++ b/src/main/java/anticope/rejects/mixin/TexturedRenderLayersMixin.java
@@ -5,19 +5,23 @@ import meteordevelopment.meteorclient.systems.modules.Modules;
 import net.minecraft.client.renderer.blockentity.ChestRenderer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @Mixin(ChestRenderer.class)
 public class TexturedRenderLayersMixin {
-    @Inject(method = "xmasTextures", at = @At("HEAD"), cancellable = true)
-    private static void onIsAroundChristmas(CallbackInfoReturnable<Boolean> cir) {
-        // Check if Modules system is initialized
+    @ModifyArg(
+        method = "extractRenderState",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/renderer/blockentity/ChestRenderer;getChestMaterial(Lnet/minecraft/world/level/block/entity/BlockEntity;Z)Lnet/minecraft/client/renderer/blockentity/state/ChestRenderState$ChestMaterialType;"
+        ),
+        index = 1
+    )
+    private boolean modifyXmasTexturesArg(boolean original) {
         if (Modules.get() != null) {
             Rendering rendering = Modules.get().get(Rendering.class);
-            if (rendering != null && rendering.chistmas()) {
-                cir.setReturnValue(true);
-            }
+            if (rendering != null && rendering.chistmas()) return true;
         }
+        return original;
     }
 }

--- a/src/main/java/anticope/rejects/modules/AntiCrash.java
+++ b/src/main/java/anticope/rejects/modules/AntiCrash.java
@@ -51,8 +51,8 @@ public class AntiCrash extends Module {
                 cancel(event);
         } else if (event.packet instanceof ClientboundSetEntityMotionPacket packet) {
             // velocity
-            if (packet.getMovement().x > 30_000_000 || packet.getMovement().y > 30_000_000 || packet.getMovement().z > 30_000_000
-                    || packet.getMovement().x < -30_000_000 || packet.getMovement().y  < -30_000_000 || packet.getMovement().z < -30_000_000
+            if (packet.getMovement().x > 1000 || packet.getMovement().y > 1000 || packet.getMovement().z > 1000
+                    || packet.getMovement().x < -1000 || packet.getMovement().y  < -1000 || packet.getMovement().z < -1000
             ) cancel(event);
         }
     }

--- a/src/main/java/anticope/rejects/modules/AntiSpawnpoint.java
+++ b/src/main/java/anticope/rejects/modules/AntiSpawnpoint.java
@@ -10,9 +10,7 @@ import meteordevelopment.orbit.EventHandler;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.protocol.game.ServerboundUseItemOnPacket;
 import net.minecraft.world.InteractionHand;
-import net.minecraft.world.attribute.BedRule;
-import net.minecraft.world.attribute.EnvironmentAttributeMap;
-import net.minecraft.world.attribute.EnvironmentAttributes;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.BedBlock;
 import net.minecraft.world.level.block.Blocks;
 
@@ -36,11 +34,9 @@ public class AntiSpawnpoint extends Module {
         if (mc.level == null) return;
         if(!(event.packet instanceof ServerboundUseItemOnPacket)) return;
 
-
         BlockPos blockPos = ((ServerboundUseItemOnPacket) event.packet).getHitResult().getBlockPos();
-        EnvironmentAttributeMap attributes = mc.level.dimensionType().attributes();
-        boolean IsOverWorld = attributes.applyModifier(EnvironmentAttributes.BED_RULE, BedRule.CAN_SLEEP_WHEN_DARK) != BedRule.CAN_SLEEP_WHEN_DARK;
-        boolean IsNetherWorld = attributes.applyModifier(EnvironmentAttributes.RESPAWN_ANCHOR_WORKS, false);
+        boolean IsOverWorld = mc.level.dimension() == Level.OVERWORLD;
+        boolean IsNetherWorld = mc.level.dimension() == Level.NETHER;
         boolean BlockIsBed = mc.level.getBlockState(blockPos).getBlock() instanceof BedBlock;
         boolean BlockIsAnchor = mc.level.getBlockState(blockPos).getBlock().equals(Blocks.RESPAWN_ANCHOR);
 

--- a/src/main/java/anticope/rejects/modules/ArrowDmg.java
+++ b/src/main/java/anticope/rejects/modules/ArrowDmg.java
@@ -2,27 +2,26 @@ package anticope.rejects.modules;
 
 import anticope.rejects.MeteorRejectsAddon;
 import anticope.rejects.events.StopUsingItemEvent;
-import meteordevelopment.meteorclient.settings.BoolSetting;
-import meteordevelopment.meteorclient.settings.IntSetting;
-import meteordevelopment.meteorclient.settings.Setting;
-import meteordevelopment.meteorclient.settings.SettingGroup;
+import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
+import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
+import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket.Pos;
 import net.minecraft.network.protocol.game.ServerboundPlayerCommandPacket;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.phys.Vec3;
 
 public class ArrowDmg extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
 
-    public final Setting<Integer> packets = sgGeneral.add(new IntSetting.Builder()
-            .name("packets")
-            .description("Amount of packets to send. More packets = higher damage.")
-            .defaultValue(200)
-            .min(2)
-            .sliderMax(2000)
+    public final Setting<Double> strength = sgGeneral.add(new DoubleSetting.Builder()
+            .name("strength")
+            .description("More strength = higher damage.")
+            .defaultValue(5)
+            .min(0.1)
+            .sliderMax(25)
             .build()
     );
 
@@ -35,7 +34,7 @@ public class ArrowDmg extends Module {
 
 
     public ArrowDmg() {
-        super(MeteorRejectsAddon.CATEGORY, "arrow-damage", "Massively increases arrow damage, but also consumes a lot of hunger and reduces accuracy. Does not work with crossbows and seems to be patched on Paper servers.");
+        super(MeteorRejectsAddon.CATEGORY, "arrow-damage", "Massively increases arrow damage, but reduces accuracy and consume more hunger. Does not work with crossbows and is patched on Paper servers.");
     }
 
     @EventHandler
@@ -52,12 +51,19 @@ public class ArrowDmg extends Module {
         double y = p.getY();
         double z = p.getZ();
 
-        for (int i = 0; i < packets.get() / 2; i++) {
-            p.connection.send(new ServerboundMovePlayerPacket.Pos(x,
-                    y - 1e-10, z, true, mc.player.horizontalCollision));
-            p.connection.send(new ServerboundMovePlayerPacket.Pos(x,
-                    y + 1e-10, z, false, mc.player.horizontalCollision));
+        double adjustedStrength = strength.get() / 10.0 * Math.sqrt(500);
+        Vec3 lookVec = p.getViewVector(1).scale(adjustedStrength);
+
+        for (int i = 0; i < 4; i++) {
+            sendPos(x, y, z, true);
         }
+        sendPos(x - lookVec.x, y, z - lookVec.z, true);
+        sendPos(x, y, z, false);
+    }
+
+    private void sendPos(double x, double y, double z, boolean onGround) {
+        ClientPacketListener clientPacketListener = mc.player.connection;
+        clientPacketListener.send(new Pos(x, y, z, onGround, mc.player.horizontalCollision));
     }
 
     private boolean isValidItem(Item item) {

--- a/src/main/java/anticope/rejects/modules/AutoCraft.java
+++ b/src/main/java/anticope/rejects/modules/AutoCraft.java
@@ -17,7 +17,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.display.RecipeDisplay;
 import net.minecraft.world.item.crafting.display.RecipeDisplayEntry;
 import net.minecraft.world.item.crafting.display.SlotDisplayContext;
-import java.util.Arrays;
+
 import java.util.List;
 
 public class AutoCraft extends Module {

--- a/src/main/java/anticope/rejects/modules/AutoEnchant.java
+++ b/src/main/java/anticope/rejects/modules/AutoEnchant.java
@@ -13,7 +13,7 @@ import net.minecraft.world.inventory.EnchantmentMenu;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.item.enchantment.EnchantmentHelper;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -50,7 +50,7 @@ public class AutoEnchant extends meteordevelopment.meteorclient.systems.modules.
             .name("item-whitelist")
             .description("Item that require enchantment.")
             .defaultValue()
-            .filter(item -> item.equals(Items.BOOK) || new ItemStack(item).isDamageableItem())
+            .filter(item -> item.equals(Items.BOOK) || new ItemStack(item).isEnchantable())
             .build()
     );
 
@@ -109,7 +109,7 @@ public class AutoEnchant extends meteordevelopment.meteorclient.systems.modules.
     }
 
     private boolean fillCanEnchantItem() {
-        FindItemResult res = InvUtils.find(stack -> itemWhitelist.get().contains(stack.getItem()) && EnchantmentHelper.canStoreEnchantments(stack));
+        FindItemResult res = InvUtils.find(stack -> itemWhitelist.get().contains(stack.getItem()));
         if (!res.found()) return false;
         InvUtils.shiftClick().slot(res.slot());
         return true;

--- a/src/main/java/anticope/rejects/modules/AutoExtinguish.java
+++ b/src/main/java/anticope/rejects/modules/AutoExtinguish.java
@@ -17,11 +17,11 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.InteractionHand;
-import net.minecraft.world.attribute.EnvironmentAttributes;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -91,7 +91,7 @@ public class AutoExtinguish extends Module {
 
     @EventHandler
     private void onTick(TickEvent.Pre event) {
-        if (mc.level.dimensionType().attributes().applyModifier(EnvironmentAttributes.RESPAWN_ANCHOR_WORKS, false)) {
+        if (mc.level.dimension() == Level.NETHER) {
             if (doesWaterBucketWork) {
                 warning("Water Buckets don't work in this dimension!");
                 doesWaterBucketWork = false;

--- a/src/main/java/anticope/rejects/modules/AutoFarm.java
+++ b/src/main/java/anticope/rejects/modules/AutoFarm.java
@@ -216,7 +216,7 @@ public class AutoFarm extends Module {
         if (block instanceof SweetBerryBushBlock)
             mc.gameMode.useItemOn(mc.player, InteractionHand.MAIN_HAND, new BlockHitResult(Utils.vec3d(pos), Direction.UP, pos, false));
         else {
-            mc.gameMode.continueDestroyBlock(pos, Direction.UP);
+            BlockUtils.breakBlock(pos, true);
         }
         return true;
     }
@@ -280,6 +280,8 @@ public class AutoFarm extends Module {
             return state.getValue(netherWartBlock.AGE) >= 3;
         } else if (block instanceof PitcherCropBlock pitcherCropBlock) {
             return state.getValue(pitcherCropBlock.AGE) >= 4;
+        } else if (block instanceof SaplingBlock) {
+            return false;
         }
         return true;
     }

--- a/src/main/java/anticope/rejects/modules/AutoGrind.java
+++ b/src/main/java/anticope/rejects/modules/AutoGrind.java
@@ -81,10 +81,11 @@ public class AutoGrind extends Module {
         int availEnchs = 0;
 
         for (Holder<Enchantment> enchantment : enchantments.keySet()) {
+            // grindstones cant remove curses
+            if (enchantment.is(EnchantmentTags.CURSE)) continue;
             availEnchs++;
-            if (EnchantmentHelper.hasTag(stack, EnchantmentTags.CURSE))
-                availEnchs--;
-            if (enchantmentBlacklist.get().contains(enchantment.value()))
+
+            if (enchantment.unwrapKey().map(enchantmentBlacklist.get()::contains).orElse(false))
                 return false;
         }
 

--- a/src/main/java/anticope/rejects/modules/AutoPot.java
+++ b/src/main/java/anticope/rejects/modules/AutoPot.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import meteordevelopment.meteorclient.events.entity.player.ItemUseCrosshairTargetEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;
+import meteordevelopment.meteorclient.pathing.BaritoneUtils;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
@@ -93,6 +94,7 @@ public class AutoPot extends Module {
 
     // TODO : Add option to scan whole inv - then either swap item to hotbar if full or just place in first empty slot
     // Note, Sometimes two or multiple splash pots are thrown - since the effect is not instant, the second pot is thrown before the effect of first is applied
+    // Need to use the splash bool that is assigned but never used
     @Override
     public void onDeactivate() {
         stopPotionUsage();
@@ -228,9 +230,11 @@ public class AutoPot extends Module {
             }
         }
         wasBaritone = false;
-        if (pauseBaritone.get() && BaritoneAPI.getProvider().getPrimaryBaritone().getPathingBehavior().isPathing()) {
-            wasBaritone = true;
-            BaritoneAPI.getProvider().getPrimaryBaritone().getCommandManager().execute("pause");
+        if (BaritoneUtils.IS_AVAILABLE) {
+            if (pauseBaritone.get() && BaritoneAPI.getProvider().getPrimaryBaritone().getPathingBehavior().isPathing()) {
+                wasBaritone = true;
+                BaritoneAPI.getProvider().getPrimaryBaritone().getCommandManager().execute("pause");
+            }
         }
     }
 

--- a/src/main/java/anticope/rejects/modules/AutoRename.java
+++ b/src/main/java/anticope/rejects/modules/AutoRename.java
@@ -9,25 +9,33 @@ import meteordevelopment.orbit.EventHandler;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.screens.inventory.AnvilScreen;
 import net.minecraft.core.component.DataComponents;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.inventory.AnvilMenu;
-import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.component.CustomData;
-import net.minecraft.world.level.block.ShulkerBoxBlock;
+import net.minecraft.world.item.component.BundleContents;
+import net.minecraft.world.item.component.ItemContainerContents;
 import java.util.List;
 
 public class AutoRename extends Module {
+    public enum ContainerType {
+        BOTH, BUNDLES, SHULKERS, NONE;
+
+        @Override
+        public String toString() {
+            return switch (this) {
+                case BOTH -> "Both";
+                case BUNDLES -> "Bundles";
+                case SHULKERS  -> "Shulkers";
+                case NONE     -> "None";
+            };
+        }
+    }
+
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
+    private final SettingGroup sgRename = settings.createGroup("Rename");
+    private final SettingGroup sgLabelContainers = settings.createGroup("Label Containers");
 
-    private final Setting<List<Item>> items = sgGeneral.add(new ItemListSetting.Builder()
-            .name("items")
-            .description("Items you want to rename.")
-            .defaultValue(List.of())
-            .build()
-    );
-
+    // General
     private final Setting<Integer> delay = sgGeneral.add(new IntSetting.Builder()
             .name("delay")
             .description("How many ticks to wait between actions.")
@@ -37,36 +45,39 @@ public class AutoRename extends Module {
             .build()
     );
 
-    private final Setting<String> name = sgGeneral.add(new StringSetting.Builder()
-            .name("name")
-            .description("Name for an item, empty for reverting name to default.")
-            .defaultValue("")
-            .build()
-    );
-
-    private final Setting<Boolean> firstItemInContainer = sgGeneral.add(new BoolSetting.Builder()
-            .name("first-item-in-container")
-            .description("Will rename containers based on name of first item in it.")
-            .defaultValue(false)
-            .build()
-    );
-
-    private final Setting<List<Item>> containerItems = sgGeneral.add(new ItemListSetting.Builder()
-            .name("container-items")
-            .description("Items to treat as containers.")
+    // Rename group
+    private final Setting<List<Item>> items = sgRename.add(new ItemListSetting.Builder()
+            .name("items")
+            .description("Items to rename.")
             .defaultValue(List.of())
             .build()
     );
 
+    private final Setting<String> name = sgRename.add(new StringSetting.Builder()
+            .name("name")
+            .description("Name to apply to items. Leave blank to keep the default name.")
+            .defaultValue("")
+            .build()
+    );
+
+    // Label Containers group
+    private final Setting<ContainerType> containerType = sgLabelContainers.add(new EnumSetting.Builder<ContainerType>()
+            .name("container-type")
+            .description("Which container types to rename based on the first item inside them.")
+            .defaultValue(ContainerType.NONE)
+            .build()
+    );
+
     public AutoRename() {
-        super(MeteorRejectsAddon.CATEGORY, "auto-rename", "Automatically renames items.");
+        super(MeteorRejectsAddon.CATEGORY, "auto-rename", "Automatically renames items at an anvil. Can also label shulkers and bundles based on their contents.");
     }
 
     private int delayLeft = 0;
+
     @EventHandler
     private void onTick(TickEvent.Post ignoredEvent) {
         if (mc.gameMode == null) return;
-        if (items.get().isEmpty()) return;
+        if (items.get().isEmpty() && containerType.get() == ContainerType.NONE) return;
         if (!(mc.player.containerMenu instanceof AnvilMenu)) return;
 
         if (delayLeft > 0) {
@@ -80,120 +91,83 @@ public class AutoRename extends Module {
         var slot1 = mc.player.containerMenu.getSlot(1);
         var slot2 = mc.player.containerMenu.getSlot(2);
         if (slot1.hasItem()) {
-//            info("Slot 1 occupied");
-            return; // touching anything
+            return; // second anvil slot occupied
         }
         if (slot2.hasItem()) {
-            if (mc.player.experienceLevel < 1) {
-//                info("No exp");
-            } else {
-//                info("Extracting named");
+            if (mc.player.experienceLevel >= 1) {
                 extractNamed();
             }
         } else {
             if (slot0.hasItem()) {
-//                info("Renaming");
                 renameItem(slot0.getItem());
             } else {
-//                info("Populating");
                 populateAnvil();
             }
         }
     }
 
+    private boolean isContainerTarget(ItemStack st) {
+        return switch (containerType.get()) {
+            case SHULKERS -> st.has(DataComponents.CONTAINER);
+            case BUNDLES  -> st.has(DataComponents.BUNDLE_CONTENTS);
+            case BOTH     -> st.has(DataComponents.CONTAINER) || st.has(DataComponents.BUNDLE_CONTENTS);
+            case NONE -> false;
+        };
+    }
+
     private void renameItem(ItemStack s) {
-        var setname = "";
-        if (firstItemInContainer.get() && containerItems.get().contains(s.getItem())) {
-            setname = getFirstItemName(s);
-        } else {
-            setname = name.get();
-        }
-//        info("Renaming");
-        if (mc.screen == null || !(mc.screen instanceof AnvilScreen)) {
+        String setname = isContainerTarget(s) ? getFirstItemName(s) : name.get();
+        if (!(mc.screen instanceof AnvilScreen)) {
             error("Not anvil screen");
             toggle();
             return;
         }
-        var widgets = mc.screen.children();
-        var input = (EditBox)widgets.get(0);
+        var input = (EditBox) mc.screen.children().get(0);
         input.setValue(setname);
     }
 
     private String getFirstItemName(ItemStack stack) {
-        Item item = stack.getItem();
-        if (!(item instanceof BlockItem && ((BlockItem) item).getBlock() instanceof ShulkerBoxBlock)) {
-            return "";
-        }
-        CompoundTag compound = stack.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).copyTag();
-        if (compound == null) {
-            return "";
-        }
-        compound = compound.getCompound("BlockEntityTag").get();
-        if (compound == null) {
-            return "";
-        }
-        var list = compound.getList("Items").get();
-        if (list == null) {
-            return "";
-        }
-        var minslot = Byte.MAX_VALUE;
-        var name = "";
-        for (int i = 0; i < list.size(); i++) {
-            var invItem = list.getCompound(i).get();
-            var invSlot = invItem.getByte("Slot").get();
-            if (minslot < invSlot) {
-                continue;
+        ItemContainerContents container = stack.get(DataComponents.CONTAINER);
+        if (container != null) {
+            for (ItemStack item : container.nonEmptyItems()) {
+                return item.getHoverName().getString();
             }
-            var itemId = invItem.getString("id");
-            if (itemId == null) {
-                continue;
-            }
-            name = String.valueOf(invItem.getCompound("Name"));
-            minslot = invSlot;
         }
-        return name;
+
+        BundleContents bundle = stack.get(DataComponents.BUNDLE_CONTENTS);
+        if (bundle != null) {
+            for (ItemStack item : bundle.items()) {
+                return item.getHoverName().getString();
+            }
+        }
+        return "";
     }
 
     private void extractNamed() {
-        var to = -1;
         var inv = mc.player.containerMenu;
         for (int i = 3; i < 38; i++) {
-            var sl = inv.getSlot(i);
-            if (sl.hasItem()) {
-                to = i;
-                break;
+            if (inv.getSlot(i).hasItem()) {
+                InvUtils.shiftClick().fromId(2).toId(i);
+                return;
             }
         }
-        if (to == -1) {
-//            info("No output slot");
-            return;
-        }
-        var from = 2;
-//        info("Shift click %d %d", from, to);
-        InvUtils.shiftClick().fromId(from).toId(to);
     }
 
     private void populateAnvil() {
-        var gItems = items.get();
-        var from = -1;
         var inv = mc.player.containerMenu;
         for (int i = 3; i < 38; i++) {
             var sl = inv.getSlot(i);
-            if (!sl.hasItem()) {
-                continue;
-            }
+            if (!sl.hasItem()) continue;
             var st = sl.getItem();
-            if (gItems.contains(st.getItem()) && !st.getComponents().has(DataComponents.CUSTOM_NAME)) {
-                from = i;
-                break;
+            boolean hasCustomName = st.getComponents().has(DataComponents.CUSTOM_NAME);
+            boolean isRenameItem = items.get().contains(st.getItem()) &&
+                    (name.get().isEmpty() ? hasCustomName : !hasCustomName);
+            boolean isContainerItem = isContainerTarget(st) && !getFirstItemName(st).isEmpty();
+
+            if (isRenameItem || (isContainerItem && !hasCustomName)) {
+                InvUtils.shiftClick().fromId(i).toId(0);
+                return;
             }
         }
-        if (from == -1) {
-//            info("Nothing to rename");
-            return;
-        }
-        var to = 0;
-//        info("Shift click %d %d", from, to);
-        InvUtils.shiftClick().fromId(from).toId(to);
     }
 }

--- a/src/main/java/anticope/rejects/modules/AutoTNT.java
+++ b/src/main/java/anticope/rejects/modules/AutoTNT.java
@@ -11,6 +11,7 @@ import meteordevelopment.meteorclient.utils.misc.Pool;
 import meteordevelopment.meteorclient.utils.player.FindItemResult;
 import meteordevelopment.meteorclient.utils.player.InvUtils;
 import meteordevelopment.meteorclient.utils.player.PlayerUtils;
+import meteordevelopment.meteorclient.utils.player.Rotations;
 import meteordevelopment.meteorclient.utils.world.BlockIterator;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.core.BlockPos;
@@ -29,7 +30,6 @@ public class AutoTNT extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
 
     // General
-
     private final Setting<Boolean> ignite = sgGeneral.add(new BoolSetting.Builder()
             .name("ignite")
             .description("Whether to ignite tnt.")
@@ -64,6 +64,17 @@ public class AutoTNT extends Module {
             .description("Whether to save flint and steel from breaking.")
             .defaultValue(true)
             .visible(ignite::get)
+            .build()
+    );
+
+    private final Setting<Integer> durability = sgGeneral.add(new IntSetting.Builder()
+            .name("durability")
+            .description("Decides the amount of durability to leave on the flint and steel")
+            .min(1)
+            .max(63)
+            .sliderMax(63)
+            .defaultValue(10)
+            .visible(antiBreak::get)
             .build()
     );
 
@@ -120,7 +131,7 @@ public class AutoTNT extends Module {
                 // Ignition
                 FindItemResult itemResult = InvUtils.findInHotbar(item -> {
                     if (item.getItem() instanceof FlintAndSteelItem) {
-                        return (antiBreak.get() && (item.getMaxDamage() - item.getDamageValue()) > 10);
+                        return !antiBreak.get() || (item.getMaxDamage() - item.getDamageValue()) > durability.get();
                     }
                     else if (item.getItem() instanceof FireChargeItem) {
                         return fireCharge.get();
@@ -128,7 +139,7 @@ public class AutoTNT extends Module {
                     return false;
                 });
                 if (!itemResult.found()) {
-                    error("No flint and steel in hotbar");
+                    error("No flint and steel in hotbar or durability too low.");
                     toggle();
                     return;
                 }
@@ -142,10 +153,13 @@ public class AutoTNT extends Module {
     }
 
     private void ignite(BlockPos pos, FindItemResult item) {
-        InvUtils.swap(item.slot(), true);
-
-        mc.gameMode.useItemOn(mc.player, InteractionHand.MAIN_HAND, new BlockHitResult(new Vec3(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5), Direction.UP, pos, true));
-
-        InvUtils.swapBack();
+        Runnable action = () -> {
+            InvUtils.swap(item.slot(), true);
+            mc.gameMode.useItemOn(mc.player, InteractionHand.MAIN_HAND, new BlockHitResult(new Vec3(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5), Direction.UP, pos, true));
+            InvUtils.swapBack();
+        };
+        // rotation is very snappy and only for the interaction, TODO improve in future
+        if (rotate.get()) Rotations.rotate(Rotations.getYaw(pos), Rotations.getPitch(pos), action);
+        else action.run();
     }
 }

--- a/src/main/java/anticope/rejects/modules/AutoWither.java
+++ b/src/main/java/anticope/rejects/modules/AutoWither.java
@@ -202,12 +202,9 @@ public class AutoWither extends Module {
             BlockUtils.place(wither.foot.above().above().relative(wither.axis, 1), findWitherSkull, rotate.get(), -50);
             
             
-            // Auto turnoff
-            if (turnOff.get()) {
-                wither = null;
-                toggle();
-            }
-            
+            wither = null;
+            if (turnOff.get()) toggle();
+
         } else {
             // Delay
             if (blockTicksWaited < blockDelay.get() - 1) {
@@ -238,16 +235,13 @@ public class AutoWither extends Module {
                     if (BlockUtils.place(wither.foot.above().above().relative(wither.axis, 1), findWitherSkull, rotate.get(), -50)) wither.stage++;
                     break;
                 case 7:
-                    // Auto turnoff
-                    if (turnOff.get()) {
-                        wither = null;
-                        toggle();
-                    }
+                    wither = null;
+                    blockTicksWaited = 0;
+                    if (turnOff.get()) toggle();
                     break;
             }
         }
-        
-        
+
         witherTicksWaited = 0;
     }
     

--- a/src/main/java/anticope/rejects/modules/BoatGlitch.java
+++ b/src/main/java/anticope/rejects/modules/BoatGlitch.java
@@ -14,7 +14,7 @@ import meteordevelopment.orbit.EventHandler;
 import net.minecraft.network.protocol.game.ServerboundInteractPacket;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.vehicle.boat.Boat;
+import net.minecraft.world.entity.vehicle.boat.AbstractBoat;
 
 public class BoatGlitch extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -85,7 +85,6 @@ public class BoatGlitch extends Module {
             }
             if (boat != null) {
                 boat.noPhysics = true;
-                //boat.pushSpeedReduction = 1;
                 dismountTicks = 5;
             }
         }
@@ -121,7 +120,7 @@ public class BoatGlitch extends Module {
     @EventHandler
     private void onKey(KeyEvent event) {
         if (event.key() == mc.options.keyShift.getDefaultKey().getValue() && event.action == KeyAction.Press) {
-            if (mc.player.getVehicle() != null && mc.player.getVehicle() instanceof Boat) {
+            if (mc.player.getVehicle() instanceof AbstractBoat) {
                 dontPhase = false;
                 boat = null;
             }

--- a/src/main/java/anticope/rejects/modules/BoatPhase.java
+++ b/src/main/java/anticope/rejects/modules/BoatPhase.java
@@ -11,7 +11,7 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.player.PlayerUtils;
 import meteordevelopment.orbit.EventHandler;
-import net.minecraft.world.entity.vehicle.boat.Boat;
+import net.minecraft.world.entity.vehicle.boat.AbstractBoat;
 import net.minecraft.world.phys.Vec3;
 
 public class BoatPhase extends Module {
@@ -73,7 +73,7 @@ public class BoatPhase extends Module {
             .build()
     );
 
-    private Boat boat = null;
+    private AbstractBoat boat = null;
 
     public BoatPhase() {
         super(MeteorRejectsAddon.CATEGORY, "boat-phase", "Phase through blocks using a boat.");
@@ -94,12 +94,12 @@ public class BoatPhase extends Module {
 
     @EventHandler
     private void onBoatMove(BoatMoveEvent event) {
-        if (mc.player.getVehicle() != null && mc.player.getVehicle() instanceof Boat) {
+        if (mc.player.getVehicle() instanceof AbstractBoat) {
             if (boat != mc.player.getVehicle()) {
                 if (boat != null) {
                     boat.noPhysics = false;
                 }
-                boat = (Boat) mc.player.getVehicle();
+                boat = (AbstractBoat) mc.player.getVehicle();
             }
         } else boat = null;
 

--- a/src/main/java/anticope/rejects/modules/ChatBot.java
+++ b/src/main/java/anticope/rejects/modules/ChatBot.java
@@ -56,7 +56,7 @@ public class ChatBot extends Module {
     }
 
     @EventHandler
-    private void onMessageRecieve(ReceiveMessageEvent event) {
+    private void onMessageReceive(ReceiveMessageEvent event) {
         String msg = event.getMessage().getString();
         if (help.get() && msg.endsWith(prefix.get() + "help")) {
             ChatUtils.sendPlayerMsg("Available commands: " + String.join(", ", commands.get().keySet()));

--- a/src/main/java/anticope/rejects/modules/ChestAura.java
+++ b/src/main/java/anticope/rejects/modules/ChestAura.java
@@ -2,7 +2,6 @@ package anticope.rejects.modules;
 
 import anticope.rejects.MeteorRejectsAddon;
 import anticope.rejects.mixininterface.IInventoryTweaks;
-import com.mojang.blaze3d.systems.RenderSystem;
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.packets.InventoryEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;

--- a/src/main/java/anticope/rejects/modules/ChorusExploit.java
+++ b/src/main/java/anticope/rejects/modules/ChorusExploit.java
@@ -137,7 +137,7 @@ public class ChorusExploit extends Module {
     }
 
     @EventHandler
-    private void onPacketRecieve(PacketEvent.Receive event) {
+    private void onPacketReceive(PacketEvent.Receive event) {
         if (event.packet instanceof ClientboundPlayerPositionPacket posPacket && ateChorus) {
             event.setCancelled(true);
             if (positionMode.get() == PositionMode.PosLook) {

--- a/src/main/java/anticope/rejects/modules/Confuse.java
+++ b/src/main/java/anticope/rejects/modules/Confuse.java
@@ -58,7 +58,7 @@ public class Confuse extends Module {
 
     private final Setting<SortPriority> priority = sgGeneral.add(new EnumSetting.Builder<SortPriority>()
             .name("priority")
-            .description("Targetting priority")
+            .description("Targeting priority")
             .defaultValue(SortPriority.LowestHealth)
             .build()
     );

--- a/src/main/java/anticope/rejects/modules/Lavacast.java
+++ b/src/main/java/anticope/rejects/modules/Lavacast.java
@@ -56,7 +56,7 @@ public class Lavacast extends Module {
     );
     private final Setting<Integer> lavaDownMult = sgShape.add(new IntSetting.Builder()
             .name("lava-down-mulipiler")
-            .description("Controlls the shape of the cast")
+            .description("Controls the shape of the cast")
             .defaultValue(40)
             .min(1)
             .sliderMax(100)
@@ -64,7 +64,7 @@ public class Lavacast extends Module {
     );
     private final Setting<Integer> lavaUpMult = sgShape.add(new IntSetting.Builder()
             .name("lava-up-mulipiler")
-            .description("Controlls the shape of the cast")
+            .description("Controls the shape of the cast")
             .defaultValue(8)
             .min(1)
             .sliderMax(100)
@@ -72,7 +72,7 @@ public class Lavacast extends Module {
     );
     private final Setting<Integer> waterDownMult = sgShape.add(new IntSetting.Builder()
             .name("water-down-mulipiler")
-            .description("Controlls the shape of the cast")
+            .description("Controls the shape of the cast")
             .defaultValue(4)
             .min(1)
             .sliderMax(100)
@@ -80,7 +80,7 @@ public class Lavacast extends Module {
     );
     private final Setting<Integer> waterUpMult = sgShape.add(new IntSetting.Builder()
             .name("water-up-mulipiler")
-            .description("Controlls the shape of the cast")
+            .description("Controls the shape of the cast")
             .defaultValue(1)
             .min(1)
             .sliderMax(100)
@@ -111,7 +111,7 @@ public class Lavacast extends Module {
         getDistance(new Vec3i(1,0,0));
         getDistance(new Vec3i(-1,0,0));
         getDistance(new Vec3i(0,0,1));
-        getDistance(new Vec3i(1,0,-1));
+        getDistance(new Vec3i(0,0,-1));
         if (dist<1) {
             error("Couldn't locate bottom.");
             toggle();
@@ -187,15 +187,14 @@ public class Lavacast extends Module {
         double y2 = y1+1;
         double z2 = z1+1;
 
-        SettingColor color = new SettingColor(128, 128, 128);
-        if (stage == Stage.LavaDown) color = new SettingColor(255, 180, 10);
-        if (stage == Stage.LavaUp) color = new SettingColor(255, 180, 128);
-        if (stage == Stage.WaterDown) color = new SettingColor(10, 10, 255);
-        if (stage == Stage.WaterUp) color = new SettingColor(128, 128, 255);
-        SettingColor color1 = color;
-        color1.a = 75;
+        SettingColor lineColor = new SettingColor(128, 128, 128);
+        if (stage == Stage.LavaDown) lineColor = new SettingColor(255, 180, 10);
+        if (stage == Stage.LavaUp) lineColor = new SettingColor(255, 180, 128);
+        if (stage == Stage.WaterDown) lineColor = new SettingColor(10, 10, 255);
+        if (stage == Stage.WaterUp) lineColor = new SettingColor(128, 128, 255);
+        SettingColor sideColor = new SettingColor(lineColor.r, lineColor.g, lineColor.b, 75);
 
-        event.renderer.box(x1, y1, z1, x2, y2, z2, color1, color, ShapeMode.Both, 0);
+        event.renderer.box(x1, y1, z1, x2, y2, z2, sideColor, lineColor, ShapeMode.Both, 0);
     }
 
     private void placeLava() {
@@ -205,10 +204,9 @@ public class Lavacast extends Module {
             toggle();
             return;
         }
-        int prevSlot = mc.player.getInventory().getSelectedSlot();
-        mc.player.getInventory().setSelectedSlot(findItemResult.slot());
-        mc.gameMode.useItem(mc.player,InteractionHand.MAIN_HAND);
-        mc.player.getInventory().setSelectedSlot(prevSlot);
+        InvUtils.swap(findItemResult.slot(), true);
+        mc.gameMode.useItem(mc.player, InteractionHand.MAIN_HAND);
+        InvUtils.swapBack();
     }
 
     private void placeWater() {
@@ -218,10 +216,9 @@ public class Lavacast extends Module {
             toggle();
             return;
         }
-        int prevSlot = mc.player.getInventory().getSelectedSlot();
-        mc.player.getInventory().setSelectedSlot(findItemResult.slot());
-        mc.gameMode.useItem(mc.player,InteractionHand.MAIN_HAND);
-        mc.player.getInventory().setSelectedSlot(prevSlot);
+        InvUtils.swap(findItemResult.slot(), true);
+        mc.gameMode.useItem(mc.player, InteractionHand.MAIN_HAND);
+        InvUtils.swapBack();
     }
 
     private void pickupLiquid() {
@@ -231,10 +228,9 @@ public class Lavacast extends Module {
             toggle();
             return;
         }
-        int prevSlot = mc.player.getInventory().getSelectedSlot();
-        mc.player.getInventory().setSelectedSlot(findItemResult.slot());
-        mc.gameMode.useItem(mc.player,InteractionHand.MAIN_HAND);
-        mc.player.getInventory().setSelectedSlot(prevSlot);
+        InvUtils.swap(findItemResult.slot(), true);
+        mc.gameMode.useItem(mc.player, InteractionHand.MAIN_HAND);
+        InvUtils.swapBack();
     }
 
     private void updateBlockBreakingProgress() {

--- a/src/main/java/anticope/rejects/modules/MossBot.java
+++ b/src/main/java/anticope/rejects/modules/MossBot.java
@@ -14,8 +14,10 @@ import meteordevelopment.orbit.EventHandler;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.Items;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -73,19 +75,18 @@ public class MossBot extends Module {
     }
 
     private int getMossSpots(BlockPos pos) {
-        if (mc.level.getBlockState(pos).getBlock() != Blocks.MOSS_BLOCK
+        Block block = mc.level.getBlockState(pos).getBlock();
+        if ((block != Blocks.MOSS_BLOCK && block != Blocks.PALE_MOSS_BLOCK)
                 || mc.level.getBlockState(pos.above()).getDestroySpeed(mc.level, pos) != 0f) {
             return 0;
         }
 
         return (int) BlockPos.withinManhattanStream(pos, 3, 4, 3)
-                .filter(b -> isMossGrowableOn(mc.level.getBlockState(b).getBlock()) && mc.level.isEmptyBlock(b.above()))
+                .filter(b -> isMossGrowableOn(mc.level.getBlockState(b)) && mc.level.isEmptyBlock(b.above()))
                 .count();
     }
 
-    private boolean isMossGrowableOn(Block block) {
-        return block == Blocks.STONE || block == Blocks.GRANITE || block == Blocks.ANDESITE || block == Blocks.DIORITE
-                || block == Blocks.DIRT || block == Blocks.COARSE_DIRT || block == Blocks.MYCELIUM || block == Blocks.GRASS_BLOCK
-                || block == Blocks.PODZOL || block == Blocks.ROOTED_DIRT;
+    private boolean isMossGrowableOn(BlockState state) {
+        return state.is(BlockTags.MOSS_REPLACEABLE);
     }
 }

--- a/src/main/java/anticope/rejects/modules/ObsidianFarm.java
+++ b/src/main/java/anticope/rejects/modules/ObsidianFarm.java
@@ -10,8 +10,8 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.InteractionHand;
-import net.minecraft.world.attribute.EnvironmentAttributes;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -36,7 +36,7 @@ public class ObsidianFarm extends Module {
         if (mc.player == null) return;
         if (mc.level == null) return;
         if (mc.gameMode == null) return;
-        if (mc.level.dimensionType().attributes().applyModifier(EnvironmentAttributes.RESPAWN_ANCHOR_WORKS, false)) {
+        if (mc.level.dimension() == Level.NETHER) {
             allowBreakAgain = true;
             return;
         }

--- a/src/main/java/anticope/rejects/modules/Rendering.java
+++ b/src/main/java/anticope/rejects/modules/Rendering.java
@@ -58,14 +58,14 @@ public class Rendering extends Module {
 	);
 
     private final Setting<Boolean> christmas = sgFun.add(new BoolSetting.Builder()
-			.name("chrismas")
+			.name("christmas")
 			.description("Chistmas chest anytime")
 			.defaultValue(false)
 			.build()
 	);
-    
+
     private PostChain shader = null;
-    
+
     public Rendering() {
         super(MeteorRejectsAddon.CATEGORY, "rendering", "Various Render Tweaks");
     }

--- a/src/main/java/anticope/rejects/modules/SkeletonESP.java
+++ b/src/main/java/anticope/rejects/modules/SkeletonESP.java
@@ -1,9 +1,6 @@
 package anticope.rejects.modules;
 
 import anticope.rejects.MeteorRejectsAddon;
-import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.math.Axis;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.settings.BoolSetting;
 import meteordevelopment.meteorclient.settings.ColorSetting;
@@ -18,11 +15,17 @@ import meteordevelopment.meteorclient.utils.player.Rotations;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import meteordevelopment.orbit.EventHandler;
+import net.minecraft.client.CameraType;
 import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.model.player.PlayerModel;
+import net.minecraft.client.renderer.entity.player.AvatarRenderer;
+import net.minecraft.client.renderer.entity.state.AvatarRenderState;
+import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Matrix4f;
-import org.joml.Quaternionf;
+import org.joml.Vector3f;
 
 public class SkeletonESP extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -42,6 +45,7 @@ public class SkeletonESP extends Module {
     );
 
     private final Freecam freecam;
+    private final Color color = new Color();
 
     public SkeletonESP() {
         super(MeteorRejectsAddon.CATEGORY, "skeleton-esp", "Looks cool as fuck");
@@ -50,170 +54,119 @@ public class SkeletonESP extends Module {
 
     @EventHandler
     private void onRender(Render3DEvent event) {
-        // NOTE: Rendering in 1.21.10 has been completely reworked to use OrderedRenderCommandQueue
-        // This module requires a full rewrite to use the new rendering pipeline
-        // The old BufferBuilder/RenderSystem API used here is no longer available
-        // See: https://fabricmc.net/2025/09/23/1219.html for migration guide
-        return;
+        float tickDelta = event.tickDelta;
+        int rotationHoldTicks = Config.get().rotationHoldTicks.get();
 
-        /* Old rendering code - kept for reference during future rewrite
-        MatrixStack matrixStack = event.matrices;
-        float g = event.tickDelta;
-
-        RenderSystem.setShader(ShaderProgramKeys.POSITION_COLOR);
-        RenderSystem.enableBlend();
-        RenderSystem.defaultBlendFunc();
-        RenderSystem.disableDepthTest();
-        RenderSystem.depthMask(MinecraftClient.getInstance().options.getGraphicsMode().getValue().getId() >= 1);
-        RenderSystem.enableCull();
-
-        mc.world.getEntities().forEach(entity -> {
-            if (!(entity instanceof PlayerEntity)) return;
-            if (mc.options.getPerspective() == Perspective.FIRST_PERSON && !freecam.isActive() && mc.player == entity)
+        mc.level.entitiesForRendering().forEach(entity -> {
+            if (!(entity instanceof Player)) return;
+            if (mc.options.getCameraType() == CameraType.FIRST_PERSON && !freecam.isActive() && mc.player == entity)
                 return;
-            int rotationHoldTicks = Config.get().rotationHoldTicks.get();
 
-            Color skeletonColor = PlayerUtils.getPlayerColor((PlayerEntity) entity, skeletonColorSetting.get());
+            Color skeletonColor = PlayerUtils.getPlayerColor((Player) entity, skeletonColorSetting.get());
             if (distance.get()) skeletonColor = getColorFromDistance(entity);
-            PlayerEntity playerEntity = (PlayerEntity) entity;
+            Player player = (Player) entity;
 
-            Vec3d footPos = getEntityRenderPosition(playerEntity, g);
-            PlayerEntityRenderer livingEntityRenderer = (PlayerEntityRenderer) (LivingEntityRenderer<?, ?>) mc.getEntityRenderDispatcher().getRenderer(playerEntity);
-            PlayerEntityModel<?> playerEntityModel = livingEntityRenderer.getModel();
+            Vec3 footPos = getEntityRenderPosition(player, tickDelta);
+            AvatarRenderer livingEntityRenderer = (AvatarRenderer) mc.getEntityRenderDispatcher().getRenderer(player);
+            PlayerModel playerModel = (PlayerModel) livingEntityRenderer.getModel();
 
-            float h = MathHelper.lerpAngleDegrees(g, playerEntity.lastBodyYaw, playerEntity.bodyYaw);
-            if (mc.player == entity && Rotations.rotationTimer < rotationHoldTicks) h = Rotations.serverYaw;
-            float j = MathHelper.lerpAngleDegrees(g, playerEntity.lastHeadYaw, playerEntity.headYaw);
-            if (mc.player == entity && Rotations.rotationTimer < rotationHoldTicks) j = Rotations.serverYaw;
+            float bodyYaw = Mth.rotLerp(tickDelta, player.yBodyRotO, player.yBodyRot);
+            if (mc.player == entity && Rotations.rotationTimer < rotationHoldTicks) bodyYaw = Rotations.serverYaw;
+            float headYaw = Mth.rotLerp(tickDelta, player.yHeadRotO, player.yHeadRot);
+            if (mc.player == entity && Rotations.rotationTimer < rotationHoldTicks) headYaw = Rotations.serverYaw;
 
-            float q = playerEntity.limbAnimator.getAnimationProgress() - playerEntity.limbAnimator.getSpeed() * (1.0F - g);
-            float p = playerEntity.limbAnimator.getAmplitude(g);
-            float o = (float) playerEntity.age + g;
-            float k = j - h;
-            float m = playerEntity.getPitch(g);
-            if (mc.player == entity && Rotations.rotationTimer < rotationHoldTicks) m = Rotations.serverPitch;
+            float ageInTicks = (float) player.tickCount + tickDelta;
+            float relativeHeadYaw = headYaw - bodyYaw;
+            float pitch = player.getViewXRot(tickDelta);
+            if (mc.player == entity && Rotations.rotationTimer < rotationHoldTicks) pitch = Rotations.serverPitch;
 
-            PlayerEntityRenderState renderState = new PlayerEntityRenderState();
-            renderState.limbSwingAnimationProgress = q;
-            renderState.limbSwingAmplitude = p;
-            renderState.age = o;
-            renderState.relativeHeadYaw = k;
-            renderState.pitch = m;
-            playerEntityModel.setAngles(renderState);
+            boolean swimming = player.isVisuallySwimming();
+            boolean sneaking = player.isCrouching();
+            boolean flying = player.isFallFlying();
 
-            boolean swimming = playerEntity.isInSwimmingPose();
-            boolean sneaking = playerEntity.isSneaking();
-            boolean flying = playerEntity.isGliding();
+            AvatarRenderState renderState = new AvatarRenderState();
+            renderState.walkAnimationPos = player.walkAnimation.position(tickDelta);
+            renderState.walkAnimationSpeed = player.walkAnimation.speed(tickDelta);
+            renderState.ageInTicks = ageInTicks;
+            renderState.yRot = relativeHeadYaw;
+            renderState.xRot = pitch;
+            playerModel.setupAnim(renderState);
 
-            ModelPart head = playerEntityModel.head;
-            ModelPart leftArm = playerEntityModel.leftArm;
-            ModelPart rightArm = playerEntityModel.rightArm;
-            ModelPart leftLeg = playerEntityModel.leftLeg;
-            ModelPart rightLeg = playerEntityModel.rightLeg;
+            ModelPart head = playerModel.head;
+            ModelPart leftArm = playerModel.leftArm;
+            ModelPart rightArm = playerModel.rightArm;
+            ModelPart leftLeg = playerModel.leftLeg;
+            ModelPart rightLeg = playerModel.rightLeg;
 
-            matrixStack.translate(footPos.x, footPos.y, footPos.z);
-            if (swimming) matrixStack.translate(0, 0.35f, 0);
+            Matrix4f outerMat = new Matrix4f();
+            if (swimming) outerMat.translate(0, 0.35f, 0);
+            outerMat.rotateY((float) Math.toRadians(-(bodyYaw + 180)));
+            if (swimming || flying) outerMat.rotateX((float) Math.toRadians(-(90 + pitch)));
+            if (swimming) outerMat.translate(0, -0.95f, 0);
 
-            matrixStack.multiply(new Quaternionf().setAngleAxis((h + 180) * Math.PI / 180F, 0, -1, 0));
-            if (swimming || flying)
-                matrixStack.multiply(new Quaternionf().setAngleAxis((90 + m) * Math.PI / 180F, -1, 0, 0));
-            if (swimming) matrixStack.translate(0, -0.95f, 0);
+            Matrix4f tiltedMat = new Matrix4f(outerMat).translate(0, 0.75f, 0);
+            if (sneaking && !swimming && !flying) tiltedMat.rotate(0.5f, -1, 0, 0);
+            tiltedMat.translate(0, -0.75f, 0);
 
-            Tessellator tessellator = Tessellator.getInstance();
-            BufferBuilder bufferBuilder = tessellator.begin(net.minecraft.client.render.VertexFormat.DrawMode.DEBUG_LINES, VertexFormats.POSITION_COLOR);
+            float hipY = sneaking ? 0.6f : 0.7f;
+            float hipZ = sneaking ? 0.23f : 0f;
+            float shoulderY = sneaking ? 1.05f : 1.35f;
+            float spineTopY = sneaking ? 1.05f : 1.4f;
 
-            Matrix4f matrix4f = matrixStack.peek().getPositionMatrix();
-            bufferBuilder.vertex(matrix4f, 0, sneaking ? 0.6f : 0.7f, sneaking ? 0.23f : 0).color(skeletonColor.r, skeletonColor.g, skeletonColor.b, skeletonColor.a);
-            bufferBuilder.vertex(matrix4f, 0, sneaking ? 1.05f : 1.4f, 0).color(skeletonColor.r, skeletonColor.g, skeletonColor.b, skeletonColor.a);//spine
-
-            bufferBuilder.vertex(matrix4f, -0.37f, sneaking ? 1.05f : 1.35f, 0).color(skeletonColor.r, skeletonColor.g, skeletonColor.b, skeletonColor.a);//shoulders
-            bufferBuilder.vertex(matrix4f, 0.37f, sneaking ? 1.05f : 1.35f, 0).color(skeletonColor.r, skeletonColor.g, skeletonColor.b, skeletonColor.a);
-
-            bufferBuilder.vertex(matrix4f, -0.15f, sneaking ? 0.6f : 0.7f, sneaking ? 0.23f : 0).color(skeletonColor.r, skeletonColor.g, skeletonColor.b, skeletonColor.a);//pelvis
-            bufferBuilder.vertex(matrix4f, 0.15f, sneaking ? 0.6f : 0.7f, sneaking ? 0.23f : 0).color(skeletonColor.r, skeletonColor.g, skeletonColor.b, skeletonColor.a);
+            // Spine
+            drawBone(event, footPos, tiltedMat, 0, hipY, hipZ, 0, spineTopY, 0, skeletonColor);
+            // Shoulders
+            drawBone(event, footPos, tiltedMat, -0.37f, shoulderY, 0, 0.37f, shoulderY, 0, skeletonColor);
+            // Pelvis
+            drawBone(event, footPos, outerMat, -0.15f, hipY, hipZ, 0.15f, hipY, hipZ, skeletonColor);
 
             // Head
-            matrixStack.push();
-            matrixStack.translate(0, sneaking ? 1.05f : 1.4f, 0);
-            rotate(matrixStack, head);
-            matrix4f = matrixStack.peek().getPositionMatrix();
-            bufferBuilder.vertex(matrix4f, 0, 0, 0).color(skeletonColor.r, skeletonColor.g, skeletonColor.b, skeletonColor.a);
-            bufferBuilder.vertex(matrix4f, 0, 0.15f, 0).color(skeletonColor.r, skeletonColor.g, skeletonColor.b, skeletonColor.a);
-            matrixStack.pop();
+            Matrix4f headMat = new Matrix4f(tiltedMat).translate(0, spineTopY, 0);
+            applyModelRot(headMat, head);
+            drawBone(event, footPos, headMat, 0, 0, 0, 0, 0.15f, 0, skeletonColor);
 
             // Right Leg
-            matrixStack.push();
-            matrixStack.translate(0.15f, sneaking ? 0.6f : 0.7f, sneaking ? 0.23f : 0);
-            rotate(matrixStack, rightLeg);
-            matrix4f = matrixStack.peek().getPositionMatrix();
-            bufferBuilder.vertex(matrix4f, 0, 0, 0).color(skeletonColor.r, skeletonColor.g, skeletonColor.b, skeletonColor.a);
-            bufferBuilder.vertex(matrix4f, 0, -0.6f, 0).color(skeletonColor.r, skeletonColor.g, skeletonColor.b, skeletonColor.a);
-            matrixStack.pop();
+            Matrix4f rightLegMat = new Matrix4f(outerMat).translate(0.15f, hipY, hipZ);
+            applyModelRot(rightLegMat, rightLeg);
+            drawBone(event, footPos, rightLegMat, 0, 0, 0, 0, -0.6f, 0, skeletonColor);
 
             // Left Leg
-            matrixStack.push();
-            matrixStack.translate(-0.15f, sneaking ? 0.6f : 0.7f, sneaking ? 0.23f : 0);
-            rotate(matrixStack, leftLeg);
-            matrix4f = matrixStack.peek().getPositionMatrix();
-            bufferBuilder.vertex(matrix4f, 0, 0, 0).color(skeletonColor.r, skeletonColor.g, skeletonColor.b, skeletonColor.a);
-            bufferBuilder.vertex(matrix4f, 0, -0.6f, 0).color(skeletonColor.r, skeletonColor.g, skeletonColor.b, skeletonColor.a);
-            matrixStack.pop();
+            Matrix4f leftLegMat = new Matrix4f(outerMat).translate(-0.15f, hipY, hipZ);
+            applyModelRot(leftLegMat, leftLeg);
+            drawBone(event, footPos, leftLegMat, 0, 0, 0, 0, -0.6f, 0, skeletonColor);
 
             // Right Arm
-            matrixStack.push();
-            matrixStack.translate(0.37f, sneaking ? 1.05f : 1.35f, 0);
-            rotate(matrixStack, rightArm);
-            matrix4f = matrixStack.peek().getPositionMatrix();
-            bufferBuilder.vertex(matrix4f, 0, 0, 0).color(skeletonColor.r, skeletonColor.g, skeletonColor.b, skeletonColor.a);
-            bufferBuilder.vertex(matrix4f, 0, -0.55f, 0).color(skeletonColor.r, skeletonColor.g, skeletonColor.b, skeletonColor.a);
-            matrixStack.pop();
+            Matrix4f rightArmMat = new Matrix4f(tiltedMat).translate(0.37f, shoulderY, 0);
+            applyModelRot(rightArmMat, rightArm);
+            drawBone(event, footPos, rightArmMat, 0, 0, 0, 0, -0.55f, 0, skeletonColor);
 
             // Left Arm
-            matrixStack.push();
-            matrixStack.translate(-0.37f, sneaking ? 1.05f : 1.35f, 0);
-            rotate(matrixStack, leftArm);
-            matrix4f = matrixStack.peek().getPositionMatrix();
-            bufferBuilder.vertex(matrix4f, 0, 0, 0).color(skeletonColor.r, skeletonColor.g, skeletonColor.b, skeletonColor.a);
-            bufferBuilder.vertex(matrix4f, 0, -0.55f, 0).color(skeletonColor.r, skeletonColor.g, skeletonColor.b, skeletonColor.a);
-            matrixStack.pop();
-
-            BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
-
-            if (swimming) matrixStack.translate(0, 0.95f, 0);
-            if (swimming || flying)
-                matrixStack.multiply(new Quaternionf().setAngleAxis((90 + m) * Math.PI / 180F, 1, 0, 0));
-            if (swimming) matrixStack.translate(0, -0.35f, 0);
-
-            matrixStack.multiply(new Quaternionf().setAngleAxis((h + 180) * Math.PI / 180F, 0, 1, 0));
-            matrixStack.translate(-footPos.x, -footPos.y, -footPos.z);
+            Matrix4f leftArmMat = new Matrix4f(tiltedMat).translate(-0.37f, shoulderY, 0);
+            applyModelRot(leftArmMat, leftArm);
+            drawBone(event, footPos, leftArmMat, 0, 0, 0, 0, -0.55f, 0, skeletonColor);
         });
-
-        RenderSystem.disableCull();
-        RenderSystem.disableBlend();
-        RenderSystem.enableDepthTest();
-        RenderSystem.depthMask(true);
-        RenderSystem.setShader(ShaderProgramKeys.POSITION_COLOR);
-        */
     }
 
-    private void rotate(PoseStack matrix, ModelPart modelPart) {
-        if (modelPart.zRot != 0.0F) {
-            matrix.mulPose(Axis.ZP.rotation(modelPart.zRot));
-        }
+    private void drawBone(Render3DEvent event, Vec3 origin, Matrix4f mat, float x1, float y1, float z1, float x2, float y2, float z2, Color color) {
+        Vector3f p1 = mat.transformPosition(new Vector3f(x1, y1, z1));
+        Vector3f p2 = mat.transformPosition(new Vector3f(x2, y2, z2));
+        event.renderer.line(
+            origin.x + p1.x, origin.y + p1.y, origin.z + p1.z,
+            origin.x + p2.x, origin.y + p2.y, origin.z + p2.z, color
+        );
+    }
 
-        if (modelPart.yRot != 0.0F) {
-            matrix.mulPose(Axis.YN.rotation(modelPart.yRot));
-        }
-
-        if (modelPart.xRot != 0.0F) {
-            matrix.mulPose(Axis.XN.rotation(modelPart.xRot));
-        }
+    private void applyModelRot(Matrix4f mat, ModelPart part) {
+        if (part.zRot != 0) mat.rotate(part.zRot, 0, 0, 1);
+        if (part.yRot != 0) mat.rotate(part.yRot, 0, -1, 0);
+        if (part.xRot != 0) mat.rotate(part.xRot, -1, 0, 0);
     }
 
     private Vec3 getEntityRenderPosition(Entity entity, double partial) {
-        double x = entity.xo + ((entity.getX() - entity.xo) * partial) - mc.getEntityRenderDispatcher().camera.position().x;
-        double y = entity.yo + ((entity.getY() - entity.yo) * partial) - mc.getEntityRenderDispatcher().camera.position().y;
-        double z = entity.zo + ((entity.getZ() - entity.zo) * partial) - mc.getEntityRenderDispatcher().camera.position().z;
+        double x = entity.xo + (entity.getX() - entity.xo) * partial;
+        double y = entity.yo + (entity.getY() - entity.yo) * partial;
+        double z = entity.zo + (entity.getZ() - entity.zo) * partial;
+
         return new Vec3(x, y, z);
     }
 

--- a/src/main/java/anticope/rejects/modules/TreeAura.java
+++ b/src/main/java/anticope/rejects/modules/TreeAura.java
@@ -15,7 +15,6 @@ import meteordevelopment.orbit.EventHandler;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.protocol.game.ServerboundUseItemOnPacket;
-import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;
@@ -167,13 +166,6 @@ public class TreeAura extends Module {
         nearby.sort(Comparator.comparingDouble(PlayerUtils::distanceTo));
         if (sortMode.get().equals(SortMode.Farthest)) Collections.reverse(nearby);
         return nearby.get(0);
-    }
-
-    private double distanceBetween(BlockPos pos1, BlockPos pos2) {
-        double d = pos1.getX() - pos2.getX();
-        double e = pos1.getY() - pos2.getY();
-        double f = pos1.getZ() - pos2.getZ();
-        return Mth.sqrt((float) (d * d + e * e + f * f));
     }
 
     public enum SortMode {Closest, Farthest}

--- a/src/main/java/anticope/rejects/modules/VehicleOneHit.java
+++ b/src/main/java/anticope/rejects/modules/VehicleOneHit.java
@@ -9,7 +9,7 @@ import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.network.protocol.game.ServerboundInteractPacket;
-import net.minecraft.world.entity.vehicle.boat.Boat;
+import net.minecraft.world.entity.vehicle.boat.AbstractBoat;
 import net.minecraft.world.entity.vehicle.minecart.AbstractMinecart;
 import net.minecraft.world.phys.EntityHitResult;
 
@@ -25,19 +25,24 @@ public class VehicleOneHit extends Module {
             .build()
     );
 
+    private boolean sending = false;
+
     public VehicleOneHit() {
         super(MeteorRejectsAddon.CATEGORY, "vehicle-one-hit", "Destroy vehicles with one hit.");
     }
 
     @EventHandler
     private void onPacketSend(PacketEvent.Send event) {
+        if (sending) return;
         if (!(event.packet instanceof ServerboundInteractPacket)
             || !(mc.hitResult instanceof EntityHitResult ehr)
-            || (!(ehr.getEntity() instanceof AbstractMinecart) && !(ehr.getEntity() instanceof Boat))
+            || (!(ehr.getEntity() instanceof AbstractMinecart) && !(ehr.getEntity() instanceof AbstractBoat))
         ) return;
 
+        sending = true;
         for (int i = 0; i < amount.get() - 1; i++) {
             mc.player.connection.getConnection().send(event.packet, null);
         }
+        sending = false;
     }
 }

--- a/src/main/java/anticope/rejects/utils/Ore.java
+++ b/src/main/java/anticope/rejects/utils/Ore.java
@@ -43,7 +43,7 @@ public class Ore {
     private static final Setting<Boolean> redstone    = new BoolSetting.Builder().name("Redstone").build();
     private static final Setting<Boolean> diamond     = new BoolSetting.Builder().name("Diamond").build();
     private static final Setting<Boolean> lapis       = new BoolSetting.Builder().name("Lapis").build();
-    private static final Setting<Boolean> copper      = new BoolSetting.Builder().name("Kappa").build();
+    private static final Setting<Boolean> copper      = new BoolSetting.Builder().name("Copper").build();
     private static final Setting<Boolean> emerald     = new BoolSetting.Builder().name("Emerald").build();
     private static final Setting<Boolean> quartz      = new BoolSetting.Builder().name("Quartz").build();
     private static final Setting<Boolean> debris      = new BoolSetting.Builder().name("Ancient Debris").build();

--- a/src/main/java/anticope/rejects/utils/accounts/CustomYggdrasilAccount.java
+++ b/src/main/java/anticope/rejects/utils/accounts/CustomYggdrasilAccount.java
@@ -3,14 +3,11 @@ package anticope.rejects.utils.accounts;
 import anticope.rejects.MeteorRejectsAddon;
 import com.mojang.authlib.exceptions.AuthenticationException;
 import com.mojang.authlib.minecraft.MinecraftSessionService;
-import meteordevelopment.meteorclient.mixin.MinecraftClientAccessor;
 import meteordevelopment.meteorclient.systems.accounts.Account;
 import meteordevelopment.meteorclient.systems.accounts.AccountType;
 import meteordevelopment.meteorclient.utils.misc.NbtException;
 import net.minecraft.client.User;
 import net.minecraft.nbt.CompoundTag;
-
-import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class CustomYggdrasilAccount extends Account<CustomYggdrasilAccount> {
     private String password, server;

--- a/src/main/resources/meteor-rejects.mixins.json
+++ b/src/main/resources/meteor-rejects.mixins.json
@@ -3,7 +3,7 @@
   "package": "anticope.rejects.mixin",
   "compatibilityLevel": "JAVA_21",
   "client": [
-    "ClientCommonNetwokHandlerMixin",
+    "ClientCommonNetworkHandlerMixin",
     "ClientPlayerInteractionManagerMixin",
     "ClientPlayNetworkHandlerMixin",
     "CommandSuggestorMixin",


### PR DESCRIPTION
moved to newer fabric loader version
fixed typos

AntiCrash - will now properly stop excessive velocity amounts
ArrowDamage - updated and now works again (thanks wurst)
AutoEnchant - whitelist is now correct - TODO many other errors
AutoFarm - Melons and pumpkins harvest correctly, saplings are now bonemealed
AutoGrind - fixed enchantment blacklist and issue with curses
AutoPot - fixed crash when baritone isnt installed
AutoRename - cleaned up logic and made it easier to understand
AutoTnt - fixed bug with anti-break mode, implemented rotation option and added a durability slider
AutoWither - fixed bug with turn-off setting
Lavacast - fixed typo that made it check diagonal and issue with colors being reused
MossBot - added support for pale moss and switched to block tags
Rendering - all renders work again, updated mixins to reflect changes
SkeletonESP - rewrote to modern rendering
VehicleOneHit - fixed bug that caused it to infinitely resend packets

misc other fixes

Note: Had some build issues with Meteor itself and resolved it by migrating a local copy of meteor to Mojang Mappings, hence why the switch of putting MavenLocal above MavenCentral. Will fix with the release of 1.26.  Or wait for this to be merged until then. 