### PR TITLE
Add Auto Drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 - ArrowDmg (Ported from [Wurst](https://github.com/Wurst-Imperium/Wurst7/tree))
 - AutoBedTrap (Ported from [BleachHack-CupEdition](https://github.com/CUPZYY/BleachHack-CupEdition/blob/master/CupEdition-1.17/src/main/java/bleach/hack/module/mods/AutoBedtrap.java))
 - AutoCraft (More generalized version of [AutoBedCraft](https://github.com/Anticope/orion/blob/main/src/main/java/me/ghosttypes/orion/modules/main/AutoBedCraft.java) from orion)
+- AutoDrop
 - AutoEnchant
 - AutoExtinguish
 - AutoFarm

--- a/src/main/java/anticope/rejects/MeteorRejectsAddon.java
+++ b/src/main/java/anticope/rejects/MeteorRejectsAddon.java
@@ -35,6 +35,7 @@ public class MeteorRejectsAddon extends MeteorAddon {
         modules.add(new AntiSpawnpoint());
         modules.add(new AntiVanish());
         modules.add(new ArrowDmg());
+        modules.add(new AutoDrop());
         modules.add(new AutoBedTrap());
         modules.add(new AutoCraft());
         modules.add(new AutoExtinguish());

--- a/src/main/java/anticope/rejects/modules/AutoDrop.java
+++ b/src/main/java/anticope/rejects/modules/AutoDrop.java
@@ -6,8 +6,8 @@ import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.player.InvUtils;
 import meteordevelopment.orbit.EventHandler;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 
 import java.util.List;
 
@@ -61,8 +61,8 @@ public class AutoDrop extends Module {
         int startSlot = dropHotbar.get() ? 0 : 9;
 
         for (int i = startSlot; i < 36; i++) {
-            ItemStack stack = mc.player.getInventory().getStack(i);
-            if (stack.isEmpty() || !items.get().contains(stack.getItem())) continue;
+            ItemStack stack = mc.player.getInventory().getItem(i);
+            if (stack == null || stack.isEmpty() || !items.get().contains(stack.getItem())) continue;
 
             InvUtils.drop().slot(i);
             return;

--- a/src/main/java/anticope/rejects/modules/AutoDrop.java
+++ b/src/main/java/anticope/rejects/modules/AutoDrop.java
@@ -4,10 +4,10 @@ import anticope.rejects.MeteorRejectsAddon;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.utils.player.InvUtils;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.screen.slot.SlotActionType;
 
 import java.util.List;
 
@@ -16,61 +16,57 @@ public class AutoDrop extends Module {
 
     private final Setting<List<Item>> items = sgGeneral.add(new ItemListSetting.Builder()
         .name("items")
-        .description("Trash list.")
+        .description("Items to automatically drop from your inventory.")
         .defaultValue(List.of())
         .build()
     );
 
-    private final Setting<Boolean> hotbar = sgGeneral.add(new BoolSetting.Builder()
-        .name("include-hotbar")
-        .description("Toss from hotbar too.")
+    private final Setting<Boolean> dropHotbar = sgGeneral.add(new BoolSetting.Builder()
+        .name("drop-hotbar")
+        .description("Also drop matching items from your hotbar.")
         .defaultValue(false)
         .build()
     );
 
     private final Setting<Integer> delay = sgGeneral.add(new IntSetting.Builder()
         .name("delay")
-        .description("Ticks between drops.")
-        .defaultValue(1)
-        .min(0)
-        .sliderMax(20)
+        .description("Delay in ticks between each drop check.")
+        .defaultValue(10)
+        .min(1)
+        .sliderMax(40)
         .build()
     );
 
-    private int ticks;
+    private int timer = 0;
 
     public AutoDrop() {
-        super(MeteorRejectsAddon.CATEGORY, "auto-drop", "Dumps trash.");
+        super(MeteorRejectsAddon.CATEGORY, "auto-drop", "Automatically drops selected items from your inventory.");
     }
 
     @Override
     public void onActivate() {
-        ticks = 0;
+        timer = 0;
     }
 
     @EventHandler
     private void onTick(TickEvent.Pre event) {
         if (mc.player == null) return;
 
-        if (ticks > 0) {
-            ticks--;
+        if (timer > 0) {
+            timer--;
             return;
         }
+        timer = delay.get();
 
-        int start = hotbar.get() ? 0 : 9;
+        // Inventory indices: 0-8 hotbar, 9-35 main inventory
+        int startSlot = dropHotbar.get() ? 0 : 9;
 
-        for (int i = start; i < 36; i++) {
+        for (int i = startSlot; i < 36; i++) {
             ItemStack stack = mc.player.getInventory().getStack(i);
-            
             if (stack.isEmpty() || !items.get().contains(stack.getItem())) continue;
 
-            // Map inv to screen handler IDs
-            int slot = i < 9 ? i + 36 : i;
-
-            mc.interactionManager.clickSlot(mc.player.playerScreenHandler.syncId, slot, 1, SlotActionType.THROW, mc.player);
-            
-            ticks = delay.get();
-            return; // drop one per cycle
+            InvUtils.drop().slot(i);
+            return; // one drop per cycle to avoid anti-cheat flags
         }
     }
 }

--- a/src/main/java/anticope/rejects/modules/AutoDrop.java
+++ b/src/main/java/anticope/rejects/modules/AutoDrop.java
@@ -12,60 +12,65 @@ import net.minecraft.screen.slot.SlotActionType;
 import java.util.List;
 
 public class AutoDrop extends Module {
-
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
 
     private final Setting<List<Item>> items = sgGeneral.add(new ItemListSetting.Builder()
         .name("items")
-        .description("Items to automatically drop from your inventory.")
+        .description("Trash list.")
         .defaultValue(List.of())
         .build()
     );
 
-    private final Setting<Boolean> dropHotbar = sgGeneral.add(new BoolSetting.Builder()
-        .name("drop-hotbar")
-        .description("Also drop matching items from your hotbar.")
+    private final Setting<Boolean> hotbar = sgGeneral.add(new BoolSetting.Builder()
+        .name("include-hotbar")
+        .description("Toss from hotbar too.")
         .defaultValue(false)
         .build()
     );
 
     private final Setting<Integer> delay = sgGeneral.add(new IntSetting.Builder()
         .name("delay")
-        .description("Delay in ticks between each drop check.")
-        .defaultValue(10)
-        .min(1)
-        .sliderMax(40)
+        .description("Ticks between drops.")
+        .defaultValue(1)
+        .min(0)
+        .sliderMax(20)
         .build()
     );
 
-    private int timer = 0;
+    private int ticks;
 
     public AutoDrop() {
-        super(MeteorRejectsAddon.CATEGORY, "auto-drop", "Automatically drops selected items from your inventory.");
+        super(MeteorRejectsAddon.CATEGORY, "auto-drop", "Dumps trash.");
+    }
+
+    @Override
+    public void onActivate() {
+        ticks = 0;
     }
 
     @EventHandler
     private void onTick(TickEvent.Pre event) {
-        if (mc.player == null || mc.interactionManager == null) return;
+        if (mc.player == null) return;
 
-        timer++;
-        if (timer < delay.get()) return;
-        timer = 0;
+        if (ticks > 0) {
+            ticks--;
+            return;
+        }
 
-        int startSlot = dropHotbar.get() ? 0 : 9;
+        int start = hotbar.get() ? 0 : 9;
 
-        for (int i = startSlot; i < mc.player.getInventory().size(); i++) {
+        for (int i = start; i < 36; i++) {
             ItemStack stack = mc.player.getInventory().getStack(i);
-            if (stack.isEmpty()) continue;
-            if (!items.get().contains(stack.getItem())) continue;
+            
+            if (stack.isEmpty() || !items.get().contains(stack.getItem())) continue;
 
-            mc.interactionManager.clickSlot(
-                mc.player.playerScreenHandler.syncId,
-                i < 9 ? i + 36 : i, // hotbar slots are offset in screen handler
-                1,
-                SlotActionType.THROW,
-                mc.player
-            );
+            // Map inv to screen handler IDs
+            int slot = i < 9 ? i + 36 : i;
+
+            mc.interactionManager.clickSlot(mc.player.playerScreenHandler.syncId, slot, 1, SlotActionType.THROW, mc.player);
+            
+            ticks = delay.get();
+            return; // drop one per cycle
         }
     }
 }

--- a/src/main/java/anticope/rejects/modules/AutoDrop.java
+++ b/src/main/java/anticope/rejects/modules/AutoDrop.java
@@ -1,0 +1,71 @@
+package anticope.rejects.modules;
+
+import anticope.rejects.MeteorRejectsAddon;
+import meteordevelopment.meteorclient.events.world.TickEvent;
+import meteordevelopment.meteorclient.settings.*;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.slot.SlotActionType;
+
+import java.util.List;
+
+public class AutoDrop extends Module {
+
+    private final SettingGroup sgGeneral = settings.getDefaultGroup();
+
+    private final Setting<List<Item>> items = sgGeneral.add(new ItemListSetting.Builder()
+        .name("items")
+        .description("Items to automatically drop from your inventory.")
+        .defaultValue(List.of())
+        .build()
+    );
+
+    private final Setting<Boolean> dropHotbar = sgGeneral.add(new BoolSetting.Builder()
+        .name("drop-hotbar")
+        .description("Also drop matching items from your hotbar.")
+        .defaultValue(false)
+        .build()
+    );
+
+    private final Setting<Integer> delay = sgGeneral.add(new IntSetting.Builder()
+        .name("delay")
+        .description("Delay in ticks between each drop check.")
+        .defaultValue(10)
+        .min(1)
+        .sliderMax(40)
+        .build()
+    );
+
+    private int timer = 0;
+
+    public AutoDrop() {
+        super(MeteorRejectsAddon.CATEGORY, "auto-drop", "Automatically drops selected items from your inventory.");
+    }
+
+    @EventHandler
+    private void onTick(TickEvent.Pre event) {
+        if (mc.player == null || mc.interactionManager == null) return;
+
+        timer++;
+        if (timer < delay.get()) return;
+        timer = 0;
+
+        int startSlot = dropHotbar.get() ? 0 : 9;
+
+        for (int i = startSlot; i < mc.player.getInventory().size(); i++) {
+            ItemStack stack = mc.player.getInventory().getStack(i);
+            if (stack.isEmpty()) continue;
+            if (!items.get().contains(stack.getItem())) continue;
+
+            mc.interactionManager.clickSlot(
+                mc.player.playerScreenHandler.syncId,
+                i < 9 ? i + 36 : i, // hotbar slots are offset in screen handler
+                1,
+                SlotActionType.THROW,
+                mc.player
+            );
+        }
+    }
+}

--- a/src/main/java/anticope/rejects/modules/AutoDrop.java
+++ b/src/main/java/anticope/rejects/modules/AutoDrop.java
@@ -58,7 +58,6 @@ public class AutoDrop extends Module {
         }
         timer = delay.get();
 
-        // Inventory indices: 0-8 hotbar, 9-35 main inventory
         int startSlot = dropHotbar.get() ? 0 : 9;
 
         for (int i = startSlot; i < 36; i++) {
@@ -66,7 +65,7 @@ public class AutoDrop extends Module {
             if (stack.isEmpty() || !items.get().contains(stack.getItem())) continue;
 
             InvUtils.drop().slot(i);
-            return; // one drop per cycle to avoid anti-cheat flags
+            return;
         }
     }
 }


### PR DESCRIPTION
Adds a new AutoDrop module that automatically drops selected items from the player's inventory. You can configure which items to drop, whether to include hotbar slots, and the tick delay between drop checks.
Related Issue
Closes #526
Motivation and Context
Requested in #526 — players often accumulate junk items (gravel, dirt, etc.) and want them automatically cleared without manual dropping.