### PR TITLE
Make ExploitPreventer optional

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,8 +62,8 @@ dependencies {
 	implementation (include('com.github.19MisterX98.SeedcrackerX:seedcrackerx-api:2.10.1')) {transitive = false}
 //	implementation (include('com.github.19MisterX98.SeedcrackerX:seedcrackerx-api:master-SNAPSHOT')) {transitive = false}
 
-	// Exploit Preventer
-	modImplementation("com.nikoverflow:exploit-preventer-api:0.0.1")
+	// Exploit Preventer (optional)
+	modCompileOnly("com.nikoverflow:exploit-preventer-api:0.0.1")
 
 	configurations.implementation.extendsFrom(configurations.extraLibs)
 }

--- a/src/main/java/anticope/rejects/mixin/meteor/modules/ServerSpoofMixin.java
+++ b/src/main/java/anticope/rejects/mixin/meteor/modules/ServerSpoofMixin.java
@@ -1,13 +1,13 @@
 package anticope.rejects.mixin.meteor.modules;
 
-import com.nikoverflow.exploitpreventer.ExploitPreventer;
-import com.nikoverflow.exploitpreventer.module.Modules;
+import anticope.rejects.utils.ExploitPreventerCompat;
 import meteordevelopment.meteorclient.settings.BoolSetting;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.modules.Category;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.misc.ServerSpoof;
+import net.fabricmc.loader.api.FabricLoader;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -15,6 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = ServerSpoof.class, remap = false)
 public class ServerSpoofMixin extends Module {
+    private static final boolean EP_LOADED = FabricLoader.getInstance().isModLoaded("exploitpreventer");
 
     private SettingGroup sgExploitPreventer;
     private Setting<Boolean> translationKey;
@@ -33,7 +34,10 @@ public class ServerSpoofMixin extends Module {
             .name("translation-key-prevention")
             .description("Prevents the server from detecting installed mods via translation keys.")
             .defaultValue(false)
-            .onChanged(val -> applyModule(Modules.TRANSLATION_KEY, val))
+            .onChanged(val -> {
+                if (!EP_LOADED) { if (val) warning("ExploitPreventer is not installed."); return; }
+                ExploitPreventerCompat.applyTranslationKey(val);
+            })
             .build()
         );
 
@@ -41,7 +45,10 @@ public class ServerSpoofMixin extends Module {
             .name("fingerprint-prevention")
             .description("Stops servers from using resource packs to uniquely identify your client.")
             .defaultValue(false)
-            .onChanged(val -> applyModule(Modules.FINGERPRINTING, val))
+            .onChanged(val -> {
+                if (!EP_LOADED) { if (val) warning("ExploitPreventer is not installed."); return; }
+                ExploitPreventerCompat.applyFingerprinting(val);
+            })
             .build()
         );
 
@@ -49,27 +56,23 @@ public class ServerSpoofMixin extends Module {
             .name("local-HTTP-request-prevention")
             .description("Blocks resource pack URLs that point to local IP addresses, prevents detection of locally running services.")
             .defaultValue(false)
-            .onChanged(val -> applyModule(Modules.LOCAL_HTTP_REQUEST, val))
+            .onChanged(val -> {
+                if (!EP_LOADED) { if (val) warning("ExploitPreventer is not installed."); return; }
+                ExploitPreventerCompat.applyLocalHTTPRequest(val);
+            })
             .build()
         );
     }
 
     @Inject(method = "onActivate", at = @At("TAIL"))
     private void onActivate(CallbackInfo ci) {
-        applyModule(Modules.TRANSLATION_KEY, translationKey.get());
-        applyModule(Modules.FINGERPRINTING, fingerprinting.get());
-        applyModule(Modules.LOCAL_HTTP_REQUEST, localHTTPRequest.get());
+        if (!EP_LOADED) return;
+        ExploitPreventerCompat.applyAll(translationKey.get(), fingerprinting.get(), localHTTPRequest.get());
     }
 
-    @Inject(method = "onDeactivate", at=@At("TAIL"), remap = false)
+    @Inject(method = "onDeactivate", at = @At("TAIL"), remap = false)
     private void onDeactivate(CallbackInfo ci) {
-        applyModule(Modules.TRANSLATION_KEY, false);
-        applyModule(Modules.FINGERPRINTING, false);
-        applyModule(Modules.LOCAL_HTTP_REQUEST, false);
-    }
-
-    private void applyModule(Modules module, boolean enabled) {
-        if (ExploitPreventer.getAPI() == null) return;
-        ExploitPreventer.getAPI().getModuleManager().getModule(module).setEnabled(enabled);
+        if (!EP_LOADED) return;
+        ExploitPreventerCompat.disableAll();
     }
 }

--- a/src/main/java/anticope/rejects/utils/ExploitPreventerCompat.java
+++ b/src/main/java/anticope/rejects/utils/ExploitPreventerCompat.java
@@ -1,0 +1,35 @@
+package anticope.rejects.utils;
+
+import com.nikoverflow.exploitpreventer.ExploitPreventer;
+import com.nikoverflow.exploitpreventer.module.Modules;
+
+public class ExploitPreventerCompat {
+    public static void applyTranslationKey(boolean enabled) {
+        apply(Modules.TRANSLATION_KEY, enabled);
+    }
+
+    public static void applyFingerprinting(boolean enabled) {
+        apply(Modules.FINGERPRINTING, enabled);
+    }
+
+    public static void applyLocalHTTPRequest(boolean enabled) {
+        apply(Modules.LOCAL_HTTP_REQUEST, enabled);
+    }
+
+    public static void applyAll(boolean translationKey, boolean fingerprinting, boolean localHTTPRequest) {
+        apply(Modules.TRANSLATION_KEY, translationKey);
+        apply(Modules.FINGERPRINTING, fingerprinting);
+        apply(Modules.LOCAL_HTTP_REQUEST, localHTTPRequest);
+    }
+
+    public static void disableAll() {
+        apply(Modules.TRANSLATION_KEY, false);
+        apply(Modules.FINGERPRINTING, false);
+        apply(Modules.LOCAL_HTTP_REQUEST, false);
+    }
+
+    private static void apply(Modules module, boolean enabled) {
+        if (ExploitPreventer.getAPI() == null) return;
+        ExploitPreventer.getAPI().getModuleManager().getModule(module).setEnabled(enabled);
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -39,5 +39,8 @@
     "java": ">=21",
     "minecraft": "~${mc_version}",
     "meteor-client": "*"
+  },
+  "suggests": {
+    "exploitpreventer": "*"
   }
 }


### PR DESCRIPTION
Fixes #531 

I incorrectly tested with my setup. But this makes ExploitPreventer optional and the game can load without it. Using the settings in ServerSpoof will give a message to the player to install it and can handle it being toggled now.