### PR TITLE
feat: append Minecraft version to build artifact name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ java {
 base {
 	archivesName = project.archives_base_name
 }
-version = project.mod_version
+version = "${project.mod_version}-${project.minecraft_version}"
 group = project.maven_group
 
 repositories {


### PR DESCRIPTION
build.gradle version set to \${mod_version}-\${minecraft_version}, producing outputs like meteor-rejects-addon-0.3-1.21.11.jar. fabric.mod.json stamped with the same version string.

## Description
<!--- Describe your changes in detail -->
Updates build.gradle to set version as ${mod_version}-${minecraft_version}, producing artifacts like meteor-rejects-addon-0.3-1.21.11.jar.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/AntiCope/meteor-rejects/issues/544

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without the Minecraft version in the artifact name, it's unclear which MC version a given jar targets. This makes it easier to identify builds. I currently have 4 different meteor-rejects-addon-0.3.jar for different versions and it's hard to differentiate.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built locally with ./gradlew build. Output jar confirmed as meteor-rejects-addon-0.3-1.21.11.jar.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] My code follows the code style of this project.
- [x] Have you successfully ran tests with your changes locally?