### PR TITLE
Update to Minecraft 26.1.2

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 21
+    - name: Set up JDK 25
       uses: actions/setup-java@v4.7.0
       with:
-        java-version: 21
+        java-version: 25
         distribution: 'zulu'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
@@ -34,9 +34,9 @@ jobs:
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest-1.21.11"
+          automatic_release_tag: "latest-26.1.2"
           prerelease: false
-          title: "1.21.11 Build"
+          title: "26.1.2 Build"
           files: |
             ./build/libs/*.jar
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 25
       uses: actions/setup-java@v4.7.0
       with:
-        java-version: 21
+        java-version: 25
         distribution: 'zulu'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://anticope.ml/pages/MeteorAddons.html"><img src="https://img.shields.io/badge/Verified%20Addon-Yes-blueviolet" alt="Verified Addon"></a>
   <a href="https://github.com/AntiCope/meteor-rejects/releases"><img src="https://img.shields.io/badge/Version-v0.1-orange" alt="Version"></a>
   <img src="https://img.shields.io/badge/spaghetti%20code-yes-success?logo=java" alt="Spaghetti code: yes">
-  <img src="https://img.shields.io/badge/Minecraft%20Version-1.21.11-blue" alt="Minecraft Version">
+  <img src="https://img.shields.io/badge/Minecraft%20Version-26.1.2-blue" alt="Minecraft Version">
   <a href="https://github.com/AntiCope/meteor-rejects/commits/master"><img src="https://img.shields.io/github/last-commit/AntiCope/meteor-rejects?logo=git" alt="Last commit"></a>
   <img src="https://img.shields.io/github/workflow/status/AntiCope/meteor-rejects/Java%20CI%20with%20Gradle?logo=github" alt="build status">
   <img src="https://img.shields.io/github/languages/code-size/AntiCope/meteor-rejects" alt="Code Size">

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 plugins {
 	id 'java'
-	id 'fabric-loom' version '1.14-SNAPSHOT'
+	id 'fabric-loom' version '1.17.19'
 }
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -27,7 +27,7 @@ repositories {
 }
 
 loom {
-	accessWidenerPath = file("src/main/resources/meteor-rejects.accesswidener")
+	accessWidenerPath = file("src/main/resources/meteor-rejects.classtweaker")
 }
 
 configurations {
@@ -42,12 +42,18 @@ dependencies {
 	extraLibs('dev.duti.acheong:cubiomes:1.22.3:osx') { transitive = false }
 	extraLibs('dev.duti.acheong:cubiomes:1.22.3:windows64') { transitive = false }
 	// To change the versions see the gradle.properties file
+	// Minecraft 26.x ships de-obfuscated, so no mappings are declared.
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings loom.officialMojangMappings()
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	// With obfuscation disabled Loom does not register the mod* configurations,
+	// so mod dependencies are declared like ordinary ones.
+	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-	modImplementation("meteordevelopment:meteor-client:${project.minecraft_version}-SNAPSHOT")
-    modCompileOnly "meteordevelopment:baritone:${project.baritone_version}-SNAPSHOT"
+	implementation("meteordevelopment:meteor-client:${project.minecraft_version}-SNAPSHOT")
+    compileOnly "meteordevelopment:baritone:${project.baritone_version}-SNAPSHOT"
+
+	// The integrated server implements Fabric API interfaces, so this is needed to compile
+	// against MinecraftServer. Meteor pulls it at runtime, which is not enough for javac.
+	compileOnly "net.fabricmc.fabric-api:fabric-resource-loader-v1:${project.fabric_resource_loader_version}"
 
 	// seed .locate and ore sim
 	extraLibs('com.seedfinding:mc_math:ffd2edcfcc0d18147549c88cc7d8ec6cf21b5b91') { transitive = false }
@@ -63,7 +69,7 @@ dependencies {
 //	implementation (include('com.github.19MisterX98.SeedcrackerX:seedcrackerx-api:master-SNAPSHOT')) {transitive = false}
 
 	// Exploit Preventer (optional)
-	modCompileOnly("com.nikoverflow:exploit-preventer-api:0.0.1")
+	compileOnly("com.nikoverflow:exploit-preventer-api:0.0.1")
 
 	configurations.implementation.extendsFrom(configurations.extraLibs)
 }
@@ -101,7 +107,7 @@ tasks.withType(JavaCompile).configureEach {
 	// The Minecraft launcher currently installs Java 8 for users, so your mod probably wants to target Java 8 too
 	// JDK 9 introduced a new way of specifying this that will make sure no newer classes or methods are used.
 	// We'll use that if it's available, but otherwise we'll use the older option.
-	def targetVersion = 21
+	def targetVersion = 25
 	if (JavaVersion.current().isJava9Compatible()) {
 		 it.options.release = targetVersion
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,18 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx2G
 
+# Minecraft 26.x ships de-obfuscated, so there are no mappings and nothing to remap.
+fabric.loom.disableObfuscation=true
+
 # Fabric Properties
-minecraft_version=1.21.11
-yarn_version=1.21.11+build.3
-loader_version=0.18.2
+minecraft_version=26.1.2
+loader_version=0.19.2
+# Matches the version Meteor Client 26.1.2 is built against
+fabric_resource_loader_version=2.0.9+d871b99e4c
 
 # Mod Properties
 mod_version = 0.3
 maven_group = anticope.rejects
 archives_base_name = meteor-rejects-addon
 
-baritone_version=1.21.11
+baritone_version=26.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/anticope/rejects/MeteorRejectsAddon.java
+++ b/src/main/java/anticope/rejects/MeteorRejectsAddon.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 
 public class MeteorRejectsAddon extends MeteorAddon {
     public static final Logger LOG = LoggerFactory.getLogger("Rejects");
-    public static final Category CATEGORY = new Category("Rejects", Items.BARRIER.getDefaultInstance());
+    public static final Category CATEGORY = new Category("Rejects", () -> Items.BARRIER.getDefaultInstance());
     public static final HudGroup HUD_GROUP = new HudGroup("Rejects");
 
     @Override

--- a/src/main/java/anticope/rejects/commands/CenterCommand.java
+++ b/src/main/java/anticope/rejects/commands/CenterCommand.java
@@ -2,7 +2,7 @@ package anticope.rejects.commands;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
-import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
 import net.minecraft.util.Mth;
 
@@ -12,7 +12,7 @@ public class CenterCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<SharedSuggestionProvider> builder) {
+    public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
         builder.then(literal("middle").executes(context -> {
             double x = Mth.floor(mc.player.getX()) + 0.5;
             double z = Mth.floor(mc.player.getZ()) + 0.5;

--- a/src/main/java/anticope/rejects/commands/ClearChatCommand.java
+++ b/src/main/java/anticope/rejects/commands/ClearChatCommand.java
@@ -2,7 +2,7 @@ package anticope.rejects.commands;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
-import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 
 public class ClearChatCommand extends Command {
     public ClearChatCommand() {
@@ -10,7 +10,7 @@ public class ClearChatCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<SharedSuggestionProvider> builder) {
+    public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
         builder.executes(context -> {
             mc.gui.getChat().clearMessages(false);
             return SINGLE_SUCCESS;

--- a/src/main/java/anticope/rejects/commands/FillCommand.java
+++ b/src/main/java/anticope/rejects/commands/FillCommand.java
@@ -3,7 +3,7 @@ package anticope.rejects.commands;
 import anticope.rejects.arguments.ClientPosArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
-import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 import net.minecraft.commands.arguments.blocks.BlockInput;
 import net.minecraft.commands.arguments.blocks.BlockStateArgument;
 import net.minecraft.core.BlockPos;
@@ -17,7 +17,7 @@ public class FillCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<SharedSuggestionProvider> builder) {
+    public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
         builder.then(argument("from-pos", ClientPosArgumentType.pos()).then(argument("to-pos", ClientPosArgumentType.pos()).then(argument("block", BlockStateArgument.block(REGISTRY_ACCESS)).executes(ctx -> {
             Vec3 fromPos = ClientPosArgumentType.getPos(ctx, "from-pos");
             Vec3 toPos = ClientPosArgumentType.getPos(ctx, "to-pos");

--- a/src/main/java/anticope/rejects/commands/GhostCommand.java
+++ b/src/main/java/anticope/rejects/commands/GhostCommand.java
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import net.minecraft.client.multiplayer.ClientPacketListener;
-import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
@@ -15,7 +15,7 @@ public class GhostCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<SharedSuggestionProvider> builder) {
+    public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
         builder.executes(ctx -> {
             execute(4);
             return SINGLE_SUCCESS;

--- a/src/main/java/anticope/rejects/commands/GiveCommand.java
+++ b/src/main/java/anticope/rejects/commands/GiveCommand.java
@@ -6,7 +6,7 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
-import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -33,7 +33,7 @@ public class GiveCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<SharedSuggestionProvider> builder) {
+    public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
         // TODO : finish this
         builder.then(literal("egg").executes(ctx -> {
             ItemStack inHand = mc.player.getMainHandItem();

--- a/src/main/java/anticope/rejects/commands/HeadsCommand.java
+++ b/src/main/java/anticope/rejects/commands/HeadsCommand.java
@@ -5,7 +5,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.gui.GuiThemes;
 import meteordevelopment.meteorclient.utils.Utils;
-import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 
 public class HeadsCommand extends Command {
 
@@ -14,7 +14,7 @@ public class HeadsCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<SharedSuggestionProvider> builder) {
+    public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
         builder.executes(ctx -> {
             Utils.screenToOpen = new HeadScreen(GuiThemes.get());
             return SINGLE_SUCCESS;

--- a/src/main/java/anticope/rejects/commands/KickCommand.java
+++ b/src/main/java/anticope/rejects/commands/KickCommand.java
@@ -4,10 +4,10 @@ import com.mojang.blaze3d.Blaze3D;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
-import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.common.ClientboundDisconnectPacket;
-import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import net.minecraft.network.protocol.game.ServerboundAttackPacket;
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
 import org.apache.commons.lang3.SystemUtils;
 
@@ -38,7 +38,7 @@ public class KickCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<SharedSuggestionProvider> builder) {
+    public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
         builder.then(literal("disconnect").executes(ctx -> {
             mc.player.connection.handleDisconnect(new ClientboundDisconnectPacket(Component.literal("Disconnected via .kick command")));
             return SINGLE_SUCCESS;
@@ -48,7 +48,7 @@ public class KickCommand extends Command {
             return SINGLE_SUCCESS;
         }));
         builder.then(literal("hurt").executes(ctx -> {
-            mc.player.connection.send(ServerboundInteractPacket.createAttackPacket(mc.player, mc.player.isShiftKeyDown()));
+            mc.player.connection.send(new ServerboundAttackPacket(mc.player.getId()));
             return SINGLE_SUCCESS;
         }));
         builder.then(literal("chat").executes(ctx -> {

--- a/src/main/java/anticope/rejects/commands/LocateCommand.java
+++ b/src/main/java/anticope/rejects/commands/LocateCommand.java
@@ -11,7 +11,7 @@ import com.seedfinding.mccore.version.MCVersion;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
-import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
@@ -35,7 +35,7 @@ public class LocateCommand extends Command {
 	}
 
 	@Override
-	public void build(LiteralArgumentBuilder<SharedSuggestionProvider> builder) {
+	public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
 		builder.then(literal("feature")
 				.then(argument("feature", EnumArgumentType.enumArgument(Cubiomes.StructureType.Village)).executes(ctx -> {
 					Cubiomes.StructureType feature = EnumArgumentType.getEnum(ctx, "feature", Cubiomes.StructureType.Village);

--- a/src/main/java/anticope/rejects/commands/PanicCommand.java
+++ b/src/main/java/anticope/rejects/commands/PanicCommand.java
@@ -4,7 +4,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
-import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 import java.util.ArrayList;
 
 public class PanicCommand extends Command {
@@ -13,7 +13,7 @@ public class PanicCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<SharedSuggestionProvider> builder) {
+    public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
         builder.executes(context -> {
             new ArrayList<>(Modules.get().getActive()).forEach(Module::toggle);
 

--- a/src/main/java/anticope/rejects/commands/ReconnectCommand.java
+++ b/src/main/java/anticope/rejects/commands/ReconnectCommand.java
@@ -7,7 +7,7 @@ import net.minecraft.client.gui.screens.TitleScreen;
 import net.minecraft.client.gui.screens.multiplayer.JoinMultiplayerScreen;
 import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.client.multiplayer.resolver.ServerAddress;
-import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 
 public class ReconnectCommand extends Command {
     public ReconnectCommand() {
@@ -15,7 +15,7 @@ public class ReconnectCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<SharedSuggestionProvider> builder) {
+    public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
         builder.executes(context -> {
             ServerData info = mc.isLocalServer() ? null : mc.getCurrentServer();
             if (info != null) {

--- a/src/main/java/anticope/rejects/commands/SaveSkinCommand.java
+++ b/src/main/java/anticope/rejects/commands/SaveSkinCommand.java
@@ -9,7 +9,7 @@ import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.commands.arguments.PlayerListEntryArgumentType;
 import meteordevelopment.meteorclient.utils.network.Http;
-import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 import net.minecraft.network.chat.Component;
 import org.apache.commons.codec.binary.Base64;
 import org.lwjgl.BufferUtils;
@@ -42,7 +42,7 @@ public class SaveSkinCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<SharedSuggestionProvider> builder) {
+    public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
         builder.then(argument("player", PlayerListEntryArgumentType.create()).executes(ctx -> {
             UUID id = PlayerListEntryArgumentType.get(ctx).getProfile().id();
             String path = TinyFileDialogs.tinyfd_saveFileDialog("Save image", null, filters, null);

--- a/src/main/java/anticope/rejects/commands/SeedCommand.java
+++ b/src/main/java/anticope/rejects/commands/SeedCommand.java
@@ -9,7 +9,7 @@ import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import com.seedfinding.mccore.version.MCVersion;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.utils.Utils;
-import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 
@@ -21,7 +21,7 @@ public class SeedCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<SharedSuggestionProvider> builder) {
+    public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
         builder.executes(ctx -> {
             Seed seed = Seeds.get().getSeed();
             if (seed == null) throw NO_SEED.create();

--- a/src/main/java/anticope/rejects/commands/ServerCommand.java
+++ b/src/main/java/anticope/rejects/commands/ServerCommand.java
@@ -9,7 +9,7 @@ import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import meteordevelopment.meteorclient.commands.Command;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.multiplayer.ServerData;
-import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
@@ -48,7 +48,7 @@ public class ServerCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<SharedSuggestionProvider> builder) {
+    public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
         builder.then(literal("ports").executes(ctx -> {
             scanKnownPorts(getAddress());
             return SINGLE_SUCCESS;

--- a/src/main/java/anticope/rejects/commands/SetBlockCommand.java
+++ b/src/main/java/anticope/rejects/commands/SetBlockCommand.java
@@ -3,7 +3,7 @@ package anticope.rejects.commands;
 import anticope.rejects.arguments.ClientPosArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
-import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 import net.minecraft.commands.arguments.blocks.BlockInput;
 import net.minecraft.commands.arguments.blocks.BlockStateArgument;
 import net.minecraft.core.BlockPos;
@@ -16,7 +16,7 @@ public class SetBlockCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<SharedSuggestionProvider> builder) {
+    public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
         builder.then(argument("pos", ClientPosArgumentType.pos()).then(argument("block", BlockStateArgument.block(REGISTRY_ACCESS)).executes(ctx -> {
             Vec3 pos = ClientPosArgumentType.getPos(ctx, "pos");
             BlockState blockState = ctx.getArgument("block", BlockInput.class).getState();

--- a/src/main/java/anticope/rejects/commands/SetVelocityCommand.java
+++ b/src/main/java/anticope/rejects/commands/SetVelocityCommand.java
@@ -3,7 +3,7 @@ package anticope.rejects.commands;
 import com.mojang.brigadier.arguments.DoubleArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
-import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 
 public class SetVelocityCommand extends Command {
     public SetVelocityCommand() {
@@ -11,7 +11,7 @@ public class SetVelocityCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<SharedSuggestionProvider> builder) {
+    public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
         builder.then(argument("y", DoubleArgumentType.doubleArg()).executes(ctx -> {
             var currentVelocity = mc.player.getDeltaMovement();
             mc.player.setDeltaMovement(currentVelocity.x, DoubleArgumentType.getDouble(ctx, "y"), currentVelocity.z);

--- a/src/main/java/anticope/rejects/commands/TeleportCommand.java
+++ b/src/main/java/anticope/rejects/commands/TeleportCommand.java
@@ -4,7 +4,7 @@ import anticope.rejects.arguments.ClientPosArgumentType;
 import com.mojang.brigadier.arguments.FloatArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
-import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 import net.minecraft.world.phys.Vec3;
 
 public class TeleportCommand extends Command {
@@ -15,7 +15,7 @@ public class TeleportCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<SharedSuggestionProvider> builder) {
+    public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
         builder.then(argument("pos", ClientPosArgumentType.pos()).executes(ctx -> {
             Vec3 pos = ClientPosArgumentType.getPos(ctx, "pos");
             mc.player.absSnapTo(pos.x(), pos.y(), pos.z());

--- a/src/main/java/anticope/rejects/commands/TerrainExport.java
+++ b/src/main/java/anticope/rejects/commands/TerrainExport.java
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import meteordevelopment.meteorclient.commands.Command;
-import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import org.lwjgl.BufferUtils;
@@ -33,7 +33,7 @@ public class TerrainExport extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<SharedSuggestionProvider> builder) {
+    public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
         builder.then(argument("distance", IntegerArgumentType.integer(1)).executes(context -> {
             int distance = IntegerArgumentType.getInteger(context, "distance");
 

--- a/src/main/java/anticope/rejects/gui/screens/InteractionScreen.java
+++ b/src/main/java/anticope/rejects/gui/screens/InteractionScreen.java
@@ -4,20 +4,21 @@ import anticope.rejects.mixin.EntityAccessor;
 import anticope.rejects.modules.InteractionMenu;
 import com.mojang.blaze3d.platform.InputConstants;
 import meteordevelopment.meteorclient.MeteorClient;
-import meteordevelopment.meteorclient.events.meteor.KeyEvent;
+import meteordevelopment.meteorclient.events.meteor.KeyInputEvent;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.misc.MeteorStarscript;
 import meteordevelopment.meteorclient.utils.render.PeekScreen;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.ChatScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import net.minecraft.world.phys.Vec3;
 import net.minecraft.network.protocol.game.ServerboundPlayerInputPacket;
 import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
@@ -99,12 +100,12 @@ public class InteractionScreen extends Screen {
                     minecraft.player.connection.send(new ServerboundPlayerInputPacket(new net.minecraft.world.entity.player.Input(false, false, false, false, false, true, false)));
 
                 }
-                minecraft.player.connection.send(ServerboundInteractPacket.createInteractionPacket(entity, true, InteractionHand.MAIN_HAND));
+                minecraft.player.connection.send(new ServerboundInteractPacket(entity.getId(), InteractionHand.MAIN_HAND, Vec3.ZERO, true));
                 minecraft.player.setShiftKeyDown(false);
             });
             case AbstractMinecartContainer storageMinecartEntity -> functions.put("Open Inventory", (Entity e) -> {
                 closeScreen();
-                minecraft.player.connection.send(ServerboundInteractPacket.createInteractionPacket(entity, true, InteractionHand.MAIN_HAND));
+                minecraft.player.connection.send(new ServerboundInteractPacket(entity.getId(), InteractionHand.MAIN_HAND, Vec3.ZERO, true));
             });
             case null, default -> functions.put("Open Inventory", (Entity e) -> {
                 closeScreen();
@@ -116,7 +117,7 @@ public class InteractionScreen extends Screen {
 
         functions.put("Spectate", (Entity e) -> {
             Minecraft.getInstance().setCameraEntity(e);
-            minecraft.player.displayClientMessage(Component.literal("Sneak to un-spectate."), true);
+            minecraft.player.sendOverlayMessage(Component.literal("Sneak to un-spectate."));
             MeteorClient.EVENT_BUS.subscribe(shiftListener);
             closeScreen();
         });
@@ -246,14 +247,14 @@ public class InteractionScreen extends Screen {
         return false;
     }
 
-    public void render(GuiGraphics context, int mouseX, int mouseY, float delta) {
+    public void extractRenderState(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta) {
         // Draw crosshair icon (simplified - using drawTexture instead)
         // context.drawGuiTexture(GUI_ICONS_TEXTURE, crosshairX - 8, crosshairY - 8, 0, 0, 15, 15);
 
         drawDots(context, (int) (Math.min(height, width) / 2 * 0.75), mouseX, mouseY);
 
         // Draw entity name (without scaling, as Matrix3x2fStack doesn't support push/pop/scale in 3D)
-        context.drawCenteredString(font, entity.getName(), width / 2, 12, 0xFFFFFFFF);
+        context.centeredText(font, entity.getName(), width / 2, 12, 0xFFFFFFFF);
 
         Vector2f mouse = getMouseVecs(mouseX, mouseY);
 
@@ -262,7 +263,7 @@ public class InteractionScreen extends Screen {
 
         minecraft.player.setYRot(yaw + mouse.x / 3);
         minecraft.player.setXRot(Mth.clamp(pitch + mouse.y / 3, -90f, 90f));
-        super.render(context, mouseX, mouseY, delta);
+        super.extractRenderState(context, mouseX, mouseY, delta);
     }
 
     private Vector2f getMouseVecs(int mouseX, int mouseY) {
@@ -281,7 +282,7 @@ public class InteractionScreen extends Screen {
         return mouse;
     }
 
-    private void drawDots(GuiGraphics context, int radius, int mouseX, int mouseY) {
+    private void drawDots(GuiGraphicsExtractor context, int radius, int mouseX, int mouseY) {
         ArrayList<Point> pointList = new ArrayList<Point>();
         String[] cache = new String[functions.size()];
         double lowestDistance = Double.MAX_VALUE;
@@ -316,44 +317,44 @@ public class InteractionScreen extends Screen {
         }
     }
 
-    private void drawRect(GuiGraphics context, int startX, int startY, int width, int height, int colorInner, int colorOuter) {
-        context.hLine(startX, startX + width, startY, colorOuter);
-        context.hLine(startX, startX + width, startY + height, colorOuter);
-        context.vLine(startX, startY, startY + height, colorOuter);
-        context.vLine(startX + width, startY, startY + height, colorOuter);
+    private void drawRect(GuiGraphicsExtractor context, int startX, int startY, int width, int height, int colorInner, int colorOuter) {
+        context.horizontalLine(startX, startX + width, startY, colorOuter);
+        context.horizontalLine(startX, startX + width, startY + height, colorOuter);
+        context.verticalLine(startX, startY, startY + height, colorOuter);
+        context.verticalLine(startX + width, startY, startY + height, colorOuter);
         context.fill(startX + 1, startY + 1, startX + width, startY + height, colorInner);
     }
 
-    private void drawTextField(GuiGraphics context, int x, int y, String key) {
+    private void drawTextField(GuiGraphicsExtractor context, int x, int y, String key) {
         if (x >= width / 2) {
             drawRect(context, x + 10, y - 8, font.width(key) + 3, 15, backgroundColor, borderColor);
-            context.drawString(font, key, x + 12, y - 4, textColor);
+            context.text(font, key, x + 12, y - 4, textColor);
         } else {
             drawRect(context, x - 14 - font.width(key), y - 8, font.width(key) + 3, 15, backgroundColor, borderColor);
-            context.drawString(font, key, x - 12 - font.width(key), y - 4, textColor);
+            context.text(font, key, x - 12 - font.width(key), y - 4, textColor);
         }
     }
 
     // Literally drawing it in code
-    private void drawDot(GuiGraphics context, int startX, int startY, int colorInner) {
+    private void drawDot(GuiGraphicsExtractor context, int startX, int startY, int colorInner) {
         // Draw dot itself
-        context.hLine(startX + 2, startX + 5, startY, borderColor);
-        context.hLine(startX + 1, startX + 6, startY + 1, borderColor);
-        context.hLine(startX + 2, startX + 5, startY + 1, colorInner);
+        context.horizontalLine(startX + 2, startX + 5, startY, borderColor);
+        context.horizontalLine(startX + 1, startX + 6, startY + 1, borderColor);
+        context.horizontalLine(startX + 2, startX + 5, startY + 1, colorInner);
         context.fill(startX, startY + 2, startX + 8, startY + 6, borderColor);
         context.fill(startX + 1, startY + 2, startX + 7, startY + 6, colorInner);
-        context.hLine(startX + 1, startX + 6, startY + 6, borderColor);
-        context.hLine(startX + 2, startX + 5, startY + 6, colorInner);
-        context.hLine(startX + 2, startX + 5, startY + 7, borderColor);
+        context.horizontalLine(startX + 1, startX + 6, startY + 6, borderColor);
+        context.horizontalLine(startX + 2, startX + 5, startY + 6, colorInner);
+        context.horizontalLine(startX + 2, startX + 5, startY + 7, borderColor);
 
         // Draw light overlay
-        context.hLine(startX + 2, startX + 3, startY + 1, 0x80FFFFFF);
-        context.hLine(startX + 1, startX + 1, startY + 2, 0x80FFFFFF);
+        context.horizontalLine(startX + 2, startX + 3, startY + 1, 0x80FFFFFF);
+        context.horizontalLine(startX + 1, startX + 1, startY + 2, 0x80FFFFFF);
     }
 
     private class StaticListener {
         @EventHandler
-        private void onKey(KeyEvent event) {
+        private void onKey(KeyInputEvent event) {
             if (event.key() == minecraft.options.keyShift.getDefaultKey().getValue()) {
                 minecraft.setCameraEntity(minecraft.player);
                 event.cancel();

--- a/src/main/java/anticope/rejects/mixin/CommandSuggestorMixin.java
+++ b/src/main/java/anticope/rejects/mixin/CommandSuggestorMixin.java
@@ -3,7 +3,7 @@ package anticope.rejects.mixin;
 import anticope.rejects.mixininterface.INoRender;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.render.NoRender;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.CommandSuggestions;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -12,8 +12,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(CommandSuggestions.class)
 public class CommandSuggestorMixin {
-    @Inject(method = "render", at = @At(value = "HEAD"), cancellable = true)
-    public void onRenderCommandSuggestion(GuiGraphics context, int mouseX, int mouseY, CallbackInfo info) {
+    @Inject(method = "extractRenderState", at = @At(value = "HEAD"), cancellable = true)
+    public void onRenderCommandSuggestion(GuiGraphicsExtractor context, int mouseX, int mouseY, CallbackInfo info) {
         if (((INoRender) Modules.get().get(NoRender.class)).noCommandSuggestions()) info.cancel();
     }
 }

--- a/src/main/java/anticope/rejects/mixin/meteor/ModuleMixin.java
+++ b/src/main/java/anticope/rejects/mixin/meteor/ModuleMixin.java
@@ -1,5 +1,6 @@
 package anticope.rejects.mixin.meteor;
 
+import anticope.rejects.mixininterface.IServerSpoof;
 import anticope.rejects.utils.RejectsConfig;
 import anticope.rejects.utils.RejectsUtils;
 import meteordevelopment.meteorclient.systems.modules.Category;
@@ -24,5 +25,16 @@ public class ModuleMixin {
             this.name = RejectsUtils.getModuleName(name);
             this.title = Utils.nameToTitle(this.name);
         }
+    }
+
+    // ServerSpoof stopped overriding these, so its Exploit Preventer hooks ride along on Module.
+    @Inject(method = "onActivate", at = @At("TAIL"))
+    private void onActivate(CallbackInfo info) {
+        if (this instanceof IServerSpoof spoof) spoof.rejects$applyExploitPreventer();
+    }
+
+    @Inject(method = "onDeactivate", at = @At("TAIL"))
+    private void onDeactivate(CallbackInfo info) {
+        if (this instanceof IServerSpoof spoof) spoof.rejects$disableExploitPreventer();
     }
 }

--- a/src/main/java/anticope/rejects/mixin/meteor/modules/InventoryTweaksMixin.java
+++ b/src/main/java/anticope/rejects/mixin/meteor/modules/InventoryTweaksMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class InventoryTweaksMixin implements IInventoryTweaks {
     private Runnable callback;
 
-    @Inject(method = "lambda$steal$4", at = @At("RETURN"))
+    @Inject(method = "lambda$steal$0", at = @At("RETURN"))
     private void afterSteal(AbstractContainerMenu handler, CallbackInfo info) {
         if (callback != null) {
             callback.run();

--- a/src/main/java/anticope/rejects/mixin/meteor/modules/ServerSpoofMixin.java
+++ b/src/main/java/anticope/rejects/mixin/meteor/modules/ServerSpoofMixin.java
@@ -1,5 +1,6 @@
 package anticope.rejects.mixin.meteor.modules;
 
+import anticope.rejects.mixininterface.IServerSpoof;
 import anticope.rejects.utils.ExploitPreventerCompat;
 import meteordevelopment.meteorclient.settings.BoolSetting;
 import meteordevelopment.meteorclient.settings.Setting;
@@ -14,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = ServerSpoof.class, remap = false)
-public class ServerSpoofMixin extends Module {
+public class ServerSpoofMixin extends Module implements IServerSpoof {
     private static final boolean EP_LOADED = FabricLoader.getInstance().isModLoaded("exploitpreventer");
 
     private SettingGroup sgExploitPreventer;
@@ -64,14 +65,16 @@ public class ServerSpoofMixin extends Module {
         );
     }
 
-    @Inject(method = "onActivate", at = @At("TAIL"))
-    private void onActivate(CallbackInfo ci) {
+    // ServerSpoof no longer overrides onActivate/onDeactivate, so there is nothing to inject
+    // into here. ModuleMixin calls these when the module is toggled.
+    @Override
+    public void rejects$applyExploitPreventer() {
         if (!EP_LOADED) return;
         ExploitPreventerCompat.applyAll(translationKey.get(), fingerprinting.get(), localHTTPRequest.get());
     }
 
-    @Inject(method = "onDeactivate", at = @At("TAIL"), remap = false)
-    private void onDeactivate(CallbackInfo ci) {
+    @Override
+    public void rejects$disableExploitPreventer() {
         if (!EP_LOADED) return;
         ExploitPreventerCompat.disableAll();
     }

--- a/src/main/java/anticope/rejects/mixininterface/IServerSpoof.java
+++ b/src/main/java/anticope/rejects/mixininterface/IServerSpoof.java
@@ -1,0 +1,11 @@
+package anticope.rejects.mixininterface;
+
+/**
+ * ServerSpoof no longer overrides onActivate/onDeactivate as of Meteor 26.1, so the
+ * Exploit Preventer hooks are driven from ModuleMixin through this interface instead.
+ */
+public interface IServerSpoof {
+    void rejects$applyExploitPreventer();
+
+    void rejects$disableExploitPreventer();
+}

--- a/src/main/java/anticope/rejects/modules/AntiCrash.java
+++ b/src/main/java/anticope/rejects/modules/AntiCrash.java
@@ -51,8 +51,8 @@ public class AntiCrash extends Module {
                 cancel(event);
         } else if (event.packet instanceof ClientboundSetEntityMotionPacket packet) {
             // velocity
-            if (packet.getMovement().x > 1000 || packet.getMovement().y > 1000 || packet.getMovement().z > 1000
-                    || packet.getMovement().x < -1000 || packet.getMovement().y  < -1000 || packet.getMovement().z < -1000
+            if (packet.movement().x > 1000 || packet.movement().y > 1000 || packet.movement().z > 1000
+                    || packet.movement().x < -1000 || packet.movement().y  < -1000 || packet.movement().z < -1000
             ) cancel(event);
         }
     }

--- a/src/main/java/anticope/rejects/modules/AutoCraft.java
+++ b/src/main/java/anticope/rejects/modules/AutoCraft.java
@@ -10,7 +10,7 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.client.gui.screens.recipebook.RecipeCollection;
-import net.minecraft.world.inventory.ClickType;
+import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.CraftingMenu;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -83,8 +83,8 @@ public class AutoCraft extends Module {
                     if (!itemList.contains(resultStack.getItem())) continue;
 
                     mc.gameMode.handlePlaceRecipe(currentScreenHandler.containerId, recipe.id(), craftAll.get());
-                    mc.gameMode.handleInventoryMouseClick(currentScreenHandler.containerId, 0, 1,
-                            drop.get() ? ClickType.THROW : ClickType.QUICK_MOVE, mc.player);
+                    mc.gameMode.handleContainerInput(currentScreenHandler.containerId, 0, 1,
+                            drop.get() ? ContainerInput.THROW : ContainerInput.QUICK_MOVE, mc.player);
                 }
             }
         }

--- a/src/main/java/anticope/rejects/modules/AutoFarm.java
+++ b/src/main/java/anticope/rejects/modules/AutoFarm.java
@@ -26,7 +26,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.CocoaBlock;
 import net.minecraft.world.level.block.CropBlock;
-import net.minecraft.world.level.block.FarmBlock;
+import net.minecraft.world.level.block.FarmlandBlock;
 import net.minecraft.world.level.block.MushroomBlock;
 import net.minecraft.world.level.block.NetherWartBlock;
 import net.minecraft.world.level.block.PitcherCropBlock;
@@ -214,7 +214,7 @@ public class AutoFarm extends Module {
         if (!harvestBlocks.get().contains(block)) return false;
         if (!isMature(state, block)) return false;
         if (block instanceof SweetBerryBushBlock)
-            mc.gameMode.useItemOn(mc.player, InteractionHand.MAIN_HAND, new BlockHitResult(Utils.vec3d(pos), Direction.UP, pos, false));
+            mc.gameMode.useItemOn(mc.player, InteractionHand.MAIN_HAND, new BlockHitResult(Utils.vec3(pos), Direction.UP, pos, false));
         else {
             BlockUtils.breakBlock(pos, true);
         }
@@ -233,7 +233,7 @@ public class AutoFarm extends Module {
                     break;
                 }
             }
-        } else if (block instanceof FarmBlock) {
+        } else if (block instanceof FarmlandBlock) {
             findItemResult = InvUtils.find(itemStack -> {
                 Item item = itemStack.getItem();
                 return item != Items.NETHER_WART && plantItems.get().contains(item);

--- a/src/main/java/anticope/rejects/modules/AutoRename.java
+++ b/src/main/java/anticope/rejects/modules/AutoRename.java
@@ -15,6 +15,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.BundleContents;
 import net.minecraft.world.item.component.ItemContainerContents;
 import java.util.List;
+import java.util.Optional;
 
 public class AutoRename extends Module {
     public enum ContainerType {
@@ -127,18 +128,17 @@ public class AutoRename extends Module {
     }
 
     private String getFirstItemName(ItemStack stack) {
+        // Container/bundle contents hold ItemStackTemplates since 26.1; the copy streams give real stacks.
         ItemContainerContents container = stack.get(DataComponents.CONTAINER);
         if (container != null) {
-            for (ItemStack item : container.nonEmptyItems()) {
-                return item.getHoverName().getString();
-            }
+            Optional<ItemStack> first = container.nonEmptyItemCopyStream().findFirst();
+            if (first.isPresent()) return first.get().getHoverName().getString();
         }
 
         BundleContents bundle = stack.get(DataComponents.BUNDLE_CONTENTS);
         if (bundle != null) {
-            for (ItemStack item : bundle.items()) {
-                return item.getHoverName().getString();
-            }
+            Optional<ItemStack> first = bundle.itemCopyStream().findFirst();
+            if (first.isPresent()) return first.get().getHoverName().getString();
         }
         return "";
     }

--- a/src/main/java/anticope/rejects/modules/BoatGlitch.java
+++ b/src/main/java/anticope/rejects/modules/BoatGlitch.java
@@ -2,7 +2,7 @@ package anticope.rejects.modules;
 
 import anticope.rejects.MeteorRejectsAddon;
 import meteordevelopment.meteorclient.events.entity.BoatMoveEvent;
-import meteordevelopment.meteorclient.events.meteor.KeyEvent;
+import meteordevelopment.meteorclient.events.meteor.KeyInputEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.settings.BoolSetting;
 import meteordevelopment.meteorclient.settings.Setting;
@@ -12,6 +12,7 @@ import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.misc.input.KeyAction;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.vehicle.boat.AbstractBoat;
@@ -110,7 +111,7 @@ public class BoatGlitch extends Module {
         if (remountTicks > 0) {
             remountTicks--;
             if (remountTicks == 0) {
-                mc.getConnection().send( ServerboundInteractPacket.createInteractionPacket(boat, false, InteractionHand.MAIN_HAND));
+                mc.getConnection().send( new ServerboundInteractPacket(boat.getId(), InteractionHand.MAIN_HAND, Vec3.ZERO, false));
                 if (toggleAfter.get()) {
                     toggle();
                 }
@@ -118,7 +119,7 @@ public class BoatGlitch extends Module {
         }
     }
     @EventHandler
-    private void onKey(KeyEvent event) {
+    private void onKey(KeyInputEvent event) {
         if (event.key() == mc.options.keyShift.getDefaultKey().getValue() && event.action == KeyAction.Press) {
             if (mc.player.getVehicle() instanceof AbstractBoat) {
                 dontPhase = false;

--- a/src/main/java/anticope/rejects/modules/BoatPhase.java
+++ b/src/main/java/anticope/rejects/modules/BoatPhase.java
@@ -2,7 +2,7 @@ package anticope.rejects.modules;
 
 import anticope.rejects.MeteorRejectsAddon;
 import meteordevelopment.meteorclient.events.entity.BoatMoveEvent;
-import meteordevelopment.meteorclient.mixininterface.IVec3d;
+import meteordevelopment.meteorclient.mixininterface.IVec3;
 import meteordevelopment.meteorclient.settings.BoolSetting;
 import meteordevelopment.meteorclient.settings.DoubleSetting;
 import meteordevelopment.meteorclient.settings.Setting;
@@ -130,7 +130,7 @@ public class BoatPhase extends Module {
                 else if (fall.get()) velY -= fallSpeed.get() / 20;
             } else if (fall.get()) velY -= fallSpeed.get() / 20;
 
-            ((IVec3d) boat.getDeltaMovement()).meteor$set(velX,velY,velZ);
+            ((IVec3) boat.getDeltaMovement()).meteor$set(velX,velY,velZ);
         }
     }
 }

--- a/src/main/java/anticope/rejects/modules/ColorSigns.java
+++ b/src/main/java/anticope/rejects/modules/ColorSigns.java
@@ -10,7 +10,6 @@ import meteordevelopment.orbit.EventHandler;
 import net.minecraft.network.protocol.game.ClientboundLoginPacket;
 import net.minecraft.network.protocol.game.ServerboundEditBookPacket;
 import net.minecraft.network.protocol.game.ServerboundSignUpdatePacket;
-import net.minecraft.server.MinecraftServer;
 
 import java.util.List;
 
@@ -69,9 +68,9 @@ public class ColorSigns extends Module {
 
     private void checkWarning() {
         assert mc.player != null;
-        MinecraftServer server = mc.player.level().getServer();
-        if (server == null) return;
-        String brand = server.getServerModName();
+        // The server brand comes from the connection; MinecraftServer is not on the client classpath.
+        if (mc.getConnection() == null) return;
+        String brand = mc.getConnection().serverBrand();
         if (brand == null) return;
         if (brand.contains("Paper")) warning("You are on a paper server. Color signs won't work here");
     }

--- a/src/main/java/anticope/rejects/modules/Jetpack.java
+++ b/src/main/java/anticope/rejects/modules/Jetpack.java
@@ -3,7 +3,7 @@ package anticope.rejects.modules;
 import anticope.rejects.MeteorRejectsAddon;
 import anticope.rejects.events.OffGroundSpeedEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;
-import meteordevelopment.meteorclient.mixininterface.IVec3d;
+import meteordevelopment.meteorclient.mixininterface.IVec3;
 import meteordevelopment.meteorclient.settings.DoubleSetting;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.settings.SettingGroup;
@@ -29,7 +29,7 @@ public class Jetpack extends Module {
     @EventHandler
     private void onTick(TickEvent.Pre event) {
         if (mc.options.keyJump.isDown()) {
-            ((IVec3d) mc.player.getDeltaMovement()).meteor$setY(jetpackSpeed.get());
+            ((IVec3) mc.player.getDeltaMovement()).meteor$setY(jetpackSpeed.get());
         }
     }
 

--- a/src/main/java/anticope/rejects/modules/KnockbackPlus.java
+++ b/src/main/java/anticope/rejects/modules/KnockbackPlus.java
@@ -2,7 +2,6 @@ package anticope.rejects.modules;
 
 import anticope.rejects.MeteorRejectsAddon;
 import meteordevelopment.meteorclient.events.packets.PacketEvent;
-import meteordevelopment.meteorclient.mixininterface.IPlayerInteractEntityC2SPacket;
 import meteordevelopment.meteorclient.settings.BoolSetting;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.settings.SettingGroup;
@@ -10,13 +9,10 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.combat.KillAura;
 import meteordevelopment.orbit.EventHandler;
-import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import net.minecraft.network.protocol.game.ServerboundAttackPacket;
 import net.minecraft.network.protocol.game.ServerboundPlayerCommandPacket;
-import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.phys.Vec3;
-import org.jspecify.annotations.NonNull;
 
 public class KnockbackPlus extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -34,26 +30,14 @@ public class KnockbackPlus extends Module {
 
     @EventHandler
     private void onSendPacket(PacketEvent.Send event) {
-        if (event.packet instanceof ServerboundInteractPacket packet) {
-            packet.dispatch(new ServerboundInteractPacket.Handler() {
-                @Override
-                public void onInteraction(@NonNull InteractionHand interactionHand) {
-                }
+        // Attacks are their own packet since 26.1; the entity is looked up from its id.
+        if (!(event.packet instanceof ServerboundAttackPacket packet)) return;
+        if (mc.player == null || mc.level == null) return;
 
-                @Override
-                public void onInteraction(@NonNull InteractionHand interactionHand, @NonNull Vec3 vec3) {
-                }
+        Entity entity = mc.level.getEntity(packet.entityId());
+        if (!(entity instanceof LivingEntity) || (entity != Modules.get().get(KillAura.class).getTarget() && ka.get()))
+            return;
 
-                @Override
-                public void onAttack() {
-                    Entity entity = ((IPlayerInteractEntityC2SPacket) packet).meteor$getEntity();
-                    if (!(entity instanceof LivingEntity) || (entity != Modules.get().get(KillAura.class).getTarget() && ka.get()))
-                        return;
-
-                    assert mc.player != null;
-                    mc.player.connection.send(new ServerboundPlayerCommandPacket(mc.player, ServerboundPlayerCommandPacket.Action.START_SPRINTING));
-                }
-            });
-        }
+        mc.player.connection.send(new ServerboundPlayerCommandPacket(mc.player, ServerboundPlayerCommandPacket.Action.START_SPRINTING));
     }
 }

--- a/src/main/java/anticope/rejects/modules/LawnBot.java
+++ b/src/main/java/anticope/rejects/modules/LawnBot.java
@@ -9,7 +9,7 @@ import meteordevelopment.orbit.EventHandler;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
-import net.minecraft.world.inventory.ClickType;
+import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;
@@ -86,7 +86,7 @@ public class LawnBot extends Module {
             if (grassInvSlot == -1)
                 return;
 
-            mc.gameMode.handleInventoryMouseClick(mc.player.containerMenu.containerId, grassInvSlot < 9 ? grassInvSlot + 36 : grassInvSlot, 8, ClickType.SWAP, mc.player);
+            mc.gameMode.handleContainerInput(mc.player.containerMenu.containerId, grassInvSlot < 9 ? grassInvSlot + 36 : grassInvSlot, 8, ContainerInput.SWAP, mc.player);
             return;
         }
 

--- a/src/main/java/anticope/rejects/modules/NewChunks.java
+++ b/src/main/java/anticope/rejects/modules/NewChunks.java
@@ -144,7 +144,7 @@ public class NewChunks extends Module {
 
 			packet.runUpdates((pos, state) -> {
 				if (!state.getFluidState().isEmpty() && !state.getFluidState().isSource()) {
-					ChunkPos chunkPos = new ChunkPos(pos);
+					ChunkPos chunkPos = ChunkPos.containing(pos);
 
 					for (Direction dir: searchDirs) {
 						if (mc.level.getBlockState(pos.relative(dir)).getFluidState().isSource() && !oldChunks.contains(chunkPos)) {
@@ -160,7 +160,7 @@ public class NewChunks extends Module {
 			ClientboundBlockUpdatePacket packet = (ClientboundBlockUpdatePacket) event.packet;
 
 			if (!packet.getBlockState().getFluidState().isEmpty() && !packet.getBlockState().getFluidState().isSource()) {
-				ChunkPos chunkPos = new ChunkPos(packet.getPos());
+				ChunkPos chunkPos = ChunkPos.containing(packet.getPos());
 
 				for (Direction dir: searchDirs) {
 					if (mc.level.getBlockState(packet.getPos().relative(dir)).getFluidState().isSource() && !oldChunks.contains(chunkPos)) {

--- a/src/main/java/anticope/rejects/modules/OreSim.java
+++ b/src/main/java/anticope/rejects/modules/OreSim.java
@@ -89,8 +89,8 @@ public class OreSim extends Module {
             return;
         }
         if (Seeds.get().getSeed() != null) {
-            int chunkX = mc.player.chunkPosition().x;
-            int chunkZ = mc.player.chunkPosition().z;
+            int chunkX = mc.player.chunkPosition().x();
+            int chunkZ = mc.player.chunkPosition().z();
 
             int rangeVal = horizontalRadius.get();
             for (int range = 0; range <= rangeVal; range++) {
@@ -106,7 +106,7 @@ public class OreSim extends Module {
     }
 
     private void renderChunk(int x, int z, Render3DEvent event) {
-        long chunkKey = ChunkPos.asLong(x,z);
+        long chunkKey = ChunkPos.pack(x,z);
 
         if (chunkRenderers.containsKey(chunkKey)) {
             Map<Ore, Set<Vec3>> chunk = chunkRenderers.get(chunkKey);
@@ -125,7 +125,7 @@ public class OreSim extends Module {
     private void onBlockUpdate(BlockUpdateEvent event) {
         if (airCheck.get() != AirCheck.RECHECK || event.newState.canOcclude()) return;
 
-        long chunkKey = ChunkPos.asLong(event.pos);
+        long chunkKey = ChunkPos.pack(event.pos);
         if (chunkRenderers.containsKey(chunkKey)) {
             Vec3 pos = Vec3.atLowerCornerOf(event.pos);
             for (var ore : chunkRenderers.get(chunkKey).values()) {
@@ -143,11 +143,11 @@ public class OreSim extends Module {
             var chunkPos = mc.player.chunkPosition();
             int rangeVal = 4;
             for (int range = 0; range <= rangeVal; ++range) {
-                for (int x = -range + chunkPos.x; x <= range + chunkPos.x; ++x) {
-                    oreGoals.addAll(addToBaritone(x, chunkPos.z + range - rangeVal));
+                for (int x = -range + chunkPos.x(); x <= range + chunkPos.x(); ++x) {
+                    oreGoals.addAll(addToBaritone(x, chunkPos.z() + range - rangeVal));
                 }
-                for (int x = -range + 1 + chunkPos.x; x < range + chunkPos.x; ++x) {
-                    oreGoals.addAll(this.addToBaritone(x, chunkPos.z - range + rangeVal + 1));
+                for (int x = -range + 1 + chunkPos.x(); x < range + chunkPos.x(); ++x) {
+                    oreGoals.addAll(this.addToBaritone(x, chunkPos.z() - range + rangeVal + 1));
                 }
             }
         }
@@ -155,7 +155,7 @@ public class OreSim extends Module {
 
     private ArrayList<BlockPos> addToBaritone(int chunkX, int chunkZ) {
         ArrayList<BlockPos> baritoneGoals = new ArrayList<>();
-        long chunkKey = ChunkPos.asLong(chunkX, chunkZ);
+        long chunkKey = ChunkPos.pack(chunkX, chunkZ);
         if (this.chunkRenderers.containsKey(chunkKey)) {
             this.chunkRenderers.get(chunkKey).entrySet().stream()
                     .filter(entry -> entry.getKey().active.get())
@@ -221,7 +221,7 @@ public class OreSim extends Module {
     private void doMathOnChunk(ChunkAccess chunk) {
 
         var chunkPos = chunk.getPos();
-        long chunkKey = chunkPos.toLong();
+        long chunkKey = chunkPos.pack();
 
         ClientLevel world = mc.level;
 
@@ -231,7 +231,7 @@ public class OreSim extends Module {
 
         Set<ResourceKey<Biome>> biomes = new HashSet<>();
         ChunkPos.rangeClosed(chunkPos, 1).forEach(chunkPosx -> {
-            ChunkAccess chunkxx = world.getChunk(chunkPosx.x, chunkPosx.z, ChunkStatus.BIOMES, false);
+            ChunkAccess chunkxx = world.getChunk(chunkPosx.x(), chunkPosx.z(), ChunkStatus.BIOMES, false);
             if (chunkxx == null) return;
 
             for(LevelChunkSection chunkSection : chunkxx.getSections()) {
@@ -240,8 +240,8 @@ public class OreSim extends Module {
         });
         Set<Ore> oreSet = biomes.stream().flatMap(b -> getDefaultOres(b).stream()).collect(Collectors.toSet());
 
-        int chunkX = chunkPos.x << 4;
-        int chunkZ = chunkPos.z << 4;
+        int chunkX = chunkPos.x() << 4;
+        int chunkZ = chunkPos.z() << 4;
         WorldgenRandom random = new WorldgenRandom(WorldgenRandom.Algorithm.XOROSHIRO.newInstance(0));
 
         long populationSeed = random.setDecorationSeed(worldSeed.seed, chunkX, chunkZ);

--- a/src/main/java/anticope/rejects/modules/ShieldBypass.java
+++ b/src/main/java/anticope/rejects/modules/ShieldBypass.java
@@ -12,7 +12,7 @@ import meteordevelopment.meteorclient.systems.modules.combat.KillAura;
 import meteordevelopment.meteorclient.utils.misc.input.KeyAction;
 import meteordevelopment.meteorclient.utils.player.InvUtils;
 import meteordevelopment.orbit.EventHandler;
-import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import net.minecraft.network.protocol.game.ServerboundAttackPacket;
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
 import net.minecraft.network.protocol.game.ServerboundSwingPacket;
 import net.minecraft.world.entity.Entity;
@@ -86,7 +86,7 @@ public class ShieldBypass extends Module {
 
             mc.getConnection().send(new ServerboundMovePlayerPacket.Pos(newPos.x(), newPos.y(), newPos.z(), true, false));
 
-            mc.getConnection().send(ServerboundInteractPacket.createAttackPacket(e, mc.player.isShiftKeyDown()));
+            mc.getConnection().send(new ServerboundAttackPacket(e.getId()));
             mc.getConnection().send(new ServerboundSwingPacket(mc.player.getUsedItemHand()));
             mc.player.resetOnlyAttackStrengthTicker();
 

--- a/src/main/java/anticope/rejects/modules/TreeAura.java
+++ b/src/main/java/anticope/rejects/modules/TreeAura.java
@@ -95,9 +95,9 @@ public class TreeAura extends Module {
         }
         InvUtils.swap(sapling.slot(), false);
         if (rotation.get())
-            Rotations.rotate(Rotations.getYaw(plantPos), Rotations.getPitch(plantPos), () -> mc.player.connection.send(new ServerboundUseItemOnPacket(InteractionHand.MAIN_HAND, new BlockHitResult(Utils.vec3d(plantPos), Direction.UP, plantPos, false), 0)));
+            Rotations.rotate(Rotations.getYaw(plantPos), Rotations.getPitch(plantPos), () -> mc.player.connection.send(new ServerboundUseItemOnPacket(InteractionHand.MAIN_HAND, new BlockHitResult(Utils.vec3(plantPos), Direction.UP, plantPos, false), 0)));
         else
-            mc.player.connection.send(new ServerboundUseItemOnPacket(InteractionHand.MAIN_HAND, new BlockHitResult(Utils.vec3d(plantPos), Direction.UP, plantPos, false), 0));
+            mc.player.connection.send(new ServerboundUseItemOnPacket(InteractionHand.MAIN_HAND, new BlockHitResult(Utils.vec3(plantPos), Direction.UP, plantPos, false), 0));
     }
 
     private void doBonemeal(BlockPos sapling) {
@@ -109,9 +109,9 @@ public class TreeAura extends Module {
         }
         InvUtils.swap(bonemeal.slot(), false);
         if (rotation.get())
-            Rotations.rotate(Rotations.getYaw(sapling), Rotations.getPitch(sapling), () -> mc.player.connection.send(new ServerboundUseItemOnPacket(InteractionHand.MAIN_HAND, new BlockHitResult(Utils.vec3d(sapling), Direction.UP, sapling, false), 0)));
+            Rotations.rotate(Rotations.getYaw(sapling), Rotations.getPitch(sapling), () -> mc.player.connection.send(new ServerboundUseItemOnPacket(InteractionHand.MAIN_HAND, new BlockHitResult(Utils.vec3(sapling), Direction.UP, sapling, false), 0)));
         else
-            mc.player.connection.send(new ServerboundUseItemOnPacket(InteractionHand.MAIN_HAND, new BlockHitResult(Utils.vec3d(sapling), Direction.UP, sapling, false), 0));
+            mc.player.connection.send(new ServerboundUseItemOnPacket(InteractionHand.MAIN_HAND, new BlockHitResult(Utils.vec3(sapling), Direction.UP, sapling, false), 0));
     }
 
     private boolean canPlant(BlockPos pos) {

--- a/src/main/java/anticope/rejects/modules/VehicleOneHit.java
+++ b/src/main/java/anticope/rejects/modules/VehicleOneHit.java
@@ -8,7 +8,7 @@ import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
-import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import net.minecraft.network.protocol.game.ServerboundAttackPacket;
 import net.minecraft.world.entity.vehicle.boat.AbstractBoat;
 import net.minecraft.world.entity.vehicle.minecart.AbstractMinecart;
 import net.minecraft.world.phys.EntityHitResult;
@@ -34,7 +34,7 @@ public class VehicleOneHit extends Module {
     @EventHandler
     private void onPacketSend(PacketEvent.Send event) {
         if (sending) return;
-        if (!(event.packet instanceof ServerboundInteractPacket)
+        if (!(event.packet instanceof ServerboundAttackPacket)
             || !(mc.hitResult instanceof EntityHitResult ehr)
             || (!(ehr.getEntity() instanceof AbstractMinecart) && !(ehr.getEntity() instanceof AbstractBoat))
         ) return;

--- a/src/main/java/anticope/rejects/utils/RejectsUtils.java
+++ b/src/main/java/anticope/rejects/utils/RejectsUtils.java
@@ -4,7 +4,7 @@ import anticope.rejects.MeteorRejectsAddon;
 import anticope.rejects.utils.seeds.Seeds;
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.entity.player.PlayerMoveEvent;
-import meteordevelopment.meteorclient.mixininterface.IVec3d;
+import meteordevelopment.meteorclient.mixininterface.IVec3;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.PostInit;
@@ -69,9 +69,9 @@ public class RejectsUtils {
             double xDir = Math.cos(Math.toRadians(dir + 90));
             double zDir = Math.sin(Math.toRadians(dir + 90));
 
-            ((IVec3d) event.movement).meteor$setXZ(xDir * speed, zDir * speed);
+            ((IVec3) event.movement).meteor$setXZ(xDir * speed, zDir * speed);
         } else {
-            ((IVec3d) event.movement).meteor$setXZ(0, 0);
+            ((IVec3) event.movement).meteor$setXZ(0, 0);
         }
 
         float ySpeed = 0;
@@ -80,7 +80,7 @@ public class RejectsUtils {
             ySpeed += speed;
         if (mc.options.keyShift.isDown())
             ySpeed -= speed;
-        ((IVec3d) event.movement).meteor$setY(verticalSpeedMatch ? ySpeed : ySpeed / 2);
+        ((IVec3) event.movement).meteor$setY(verticalSpeedMatch ? ySpeed : ySpeed / 2);
 
         return ySpeed;
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,13 +30,13 @@
     "meteor-rejects.mixins.json",
     "meteor-rejects-meteor.mixins.json"
   ],
-  "accessWidener": "meteor-rejects.accesswidener",
+  "accessWidener": "meteor-rejects.classtweaker",
   "custom": {
     "meteor-client:color": "227,0,0",
     "github:sha": "${gh_hash}"
   },
   "depends": {
-    "java": ">=21",
+    "java": ">=25",
     "minecraft": "~${mc_version}",
     "meteor-client": "*"
   },

--- a/src/main/resources/meteor-rejects.accesswidener
+++ b/src/main/resources/meteor-rejects.accesswidener
@@ -1,3 +1,0 @@
-accessWidener	v2	named
-
-accessible class net/minecraft/network/protocol/game/ServerboundInteractPacket$Action

--- a/src/main/resources/meteor-rejects.classtweaker
+++ b/src/main/resources/meteor-rejects.classtweaker
@@ -1,0 +1,4 @@
+classTweaker	v1	official
+
+# ServerboundInteractPacket$Action no longer exists in 26.1 - attacks are sent as
+# ServerboundAttackPacket and interactions carry their hit location directly.


### PR DESCRIPTION
Updates the addon to Minecraft 26.1.2, building against `meteor-client:26.1.2-SNAPSHOT` and `baritone:26.1-SNAPSHOT`.

## Build system

26.x ships de-obfuscated, which removes the mappings pipeline entirely:

- Dropped `mappings loom.officialMojangMappings()`. Mojang no longer publishes client/server mappings for these versions, and there is no yarn build for 26.1.2.
- Added `fabric.loom.disableObfuscation=true`, which Loom requires when there is nothing to remap. This also removes the `mod*` configurations, so mod dependencies are declared with plain `implementation`/`compileOnly`.
- Converted the AccessWidener to a ClassTweaker. Its only entry, `ServerboundInteractPacket$Action`, no longer exists.

Loom `1.14-SNAPSHOT` → `1.17.19`, Gradle `9.2.1` → `9.7.0`, Java 21 → 25 (26.1.2 requires 25), Fabric Loader `0.19.2`. CI workflows and the README badge updated to match.

`fabric-resource-loader-v1` is added as `compileOnly`: the integrated server implements Fabric API interfaces, so `MinecraftServer` is unresolvable without it. Meteor only pulls it in at runtime, which is not enough for javac.

## API changes

- Commands take `ClientSuggestionProvider` rather than `SharedSuggestionProvider`.
- `ChunkPos` is a record: `asLong`/`toLong` → `pack`, fields → accessors, `new ChunkPos(BlockPos)` → `ChunkPos.containing`.
- `GuiGraphics` → `GuiGraphicsExtractor`, with the retained-mode draw API: `render` → `extractRenderState`, `drawString` → `text`, `drawCenteredString` → `centeredText`, `hLine`/`vLine` → `horizontalLine`/`verticalLine`.
- `ClickType` → `ContainerInput` and `handleInventoryMouseClick` → `handleContainerInput`; `FarmBlock` → `FarmlandBlock`; `ClientboundSetEntityMotionPacket.getMovement` → `movement`.
- Meteor side: `KeyEvent` → `KeyInputEvent`, `IVec3d` → `IVec3`, `Utils.vec3d` → `Utils.vec3`, and `Category` now takes a `Supplier<ItemStack>` icon.
- Container and bundle contents hold `ItemStackTemplate`, so `AutoRename` reads them through the copy streams.
- `ColorSigns` reads the server brand from the connection instead of `MinecraftServer`, which is not on the client classpath.

## Attack / interact packet split

`ServerboundInteractPacket.createAttackPacket` is gone; attacks are now `ServerboundAttackPacket(entityId)`, which is what vanilla sends. The old sneaking flag does not exist in the new packet.

Interact packets always carry a hit location now — the component is non-null in the codec, so the old position-less form has no direct equivalent. Call sites that previously sent a plain interact (`InteractionScreen`, `BoatGlitch`) pass `Vec3.ZERO`, i.e. a hit at the entity origin. Flagging it in case a different value is preferred.

`KnockbackPlus` is rewritten against `ServerboundAttackPacket`; the `dispatch`/`Handler` API and the `IPlayerInteractEntityC2SPacket` mixin interface are both gone, so the entity is resolved by id from the level.

## Mixin fixes

Two stale targets that would have crashed on startup under `defaultRequire: 1`:

- `ServerSpoof` no longer overrides `onActivate`/`onDeactivate`, so there is nothing to inject into. The Exploit Preventer hooks are driven from `ModuleMixin` through a new `IServerSpoof` interface.
- `InventoryTweaks`: `lambda$steal$4` → `lambda$steal$0`.

## Testing

Builds clean on JDK 25. Verified in-game on 26.1.2 alongside Meteor Client `26.1.2-41`, Baritone, Sodium and Fabric API — all mixins apply with no errors in the log, and the addon initialises normally. I also checked every `@Inject` target and `@Shadow` member in the addon against the 26.1.2 and Meteor jars, since those fail at load rather than at compile time. Individual modules have not each been exercised in depth.
